### PR TITLE
tmux/ui: fix window sizes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -6,6 +6,7 @@ import (
 	"claude-squad/ui"
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -112,6 +113,9 @@ func (m *home) updateHandleWindowSizeEvent(msg tea.WindowSizeMsg) {
 
 	m.preview.SetSize(previewWidth, contentHeight)
 	m.list.SetSize(listWidth, contentHeight)
+	if err := m.list.SetSessionPreviewSize(ui.AdjustPreviewWidth(previewWidth), 40); err != nil {
+		log.Println(err)
+	}
 	m.menu.SetSize(msg.Width, menuHeight)
 }
 
@@ -236,7 +240,14 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	// TODO: add more key bindings
 	case keys.KeyEnter:
-		<-m.list.Attach()
+		if m.list.NumInstances() == 0 {
+			return m, nil
+		}
+		ch, err := m.list.Attach()
+		if err != nil {
+			return m.showErrorMessageForShortTime(err)
+		}
+		<-ch
 		// WindowSize clears the screen.
 		return m, tea.WindowSize()
 	default:

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,3 @@
+tmux kill-server
+rm -rf worktree*
+rm -rf ~/.claude-squad

--- a/main.go
+++ b/main.go
@@ -1,16 +1,13 @@
 package main
 
 import (
-	"bytes"
 	"claude-squad/app"
 	"claude-squad/logger"
 	"claude-squad/session"
 	"context"
 	"fmt"
-	"log"
-	"sync"
-
 	"github.com/spf13/cobra"
+	"log"
 )
 
 var (
@@ -48,41 +45,5 @@ func init() {
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)
-	}
-}
-
-type stdinListener struct {
-	mu struct {
-		*sync.Mutex
-		buf bytes.Buffer
-	}
-}
-
-func (sl *stdinListener) Write(p []byte) (n int, err error) {
-	sl.mu.Lock()
-	defer sl.mu.Unlock()
-	return sl.mu.buf.Write(p)
-}
-
-func (sl *stdinListener) Read(p []byte) (n int, err error) {
-	sl.mu.Lock()
-	defer sl.mu.Unlock()
-	return sl.mu.buf.Read(p)
-}
-
-func tmuxMain() {
-	tmux := session.NewTmuxSession("my_session")
-	defer tmux.Close()
-
-	if err := tmux.Start("claude"); err != nil {
-		log.Fatalf("Error starting tmux session: %v", err)
-	}
-
-	if err := tmux.Attach(); err != nil {
-		log.Fatalf("Error attaching to tmux session: %v", err)
-	}
-
-	if err := tmux.Detach(); err != nil {
-		log.Fatalf("Error detaching from tmux session: %v", err)
 	}
 }

--- a/ui/preview.go
+++ b/ui/preview.go
@@ -20,15 +20,19 @@ type PreviewPane struct {
 	text string
 }
 
+// AdjustPreviewWidth adjusts the width of the preview pane to be 90% of the provided width.
+func AdjustPreviewWidth(width int) int {
+	return int(float64(width) * 0.9)
+}
+
 func NewPreviewPane(width, maxHeight int) *PreviewPane {
 	// Use 70% of the provided width
-	adjustedWidth := int(float64(width) * 0.7)
+	adjustedWidth := AdjustPreviewWidth(width)
 	return &PreviewPane{width: adjustedWidth, maxHeight: maxHeight}
 }
 
 func (p *PreviewPane) SetSize(width, maxHeight int) {
-	// Use 70% of the provided width
-	p.width = int(float64(width) * 0.7)
+	p.width = AdjustPreviewWidth(width)
 	p.maxHeight = maxHeight
 }
 
@@ -63,7 +67,7 @@ func (p *PreviewPane) String() string {
 	}
 
 	// Calculate available height accounting for border and margin
-	availableHeight := p.maxHeight - 3 // 2 for borders, 1 for margin
+	availableHeight := p.maxHeight - 3 - 4 // 2 for borders, 1 for margin, 1 for ellipsis
 
 	// Split the raw text into lines first, preserving ANSI codes
 	lines := strings.Split(p.text, "\n")


### PR DESCRIPTION
This change fixes the window sizes while detached (ie. the preview window) and attached to conform to the preview pane size and terminal size respectively.

This change also refactors the *TmuxSession to be more organized and probably fixes a handful of bugs. Attaching/detaching and goroutines are managed better now so nothing leaks / is in the wrong state. Things might get corrupted if an error occurs though. We should address that in the future.