### PR TITLE
feat(session/git): Add support for checking out worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .aider*
+

--- a/app/util.go
+++ b/app/util.go
@@ -1,0 +1,14 @@
+package app
+
+import (
+	"os/exec"
+)
+
+// isWorktreeDirty checks if the current git worktree has uncommitted changes
+func isWorktreeDirty() bool {
+	// Check for changes in tracked files only
+	// git diff --quiet only checks tracked files with changes
+	cmd := exec.Command("git", "diff", "--quiet")
+	err := cmd.Run()
+	return err != nil
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.7
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.3.4
 	github.com/charmbracelet/lipgloss v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v0.20.0 h1:jSZu6qD8cRQ6k9OMfR1WlM+ruM8fkPWkHvQWD9LIutE=

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -15,10 +15,13 @@ const (
 	KeyQuit
 	KeyReview
 	KeyPush
-	KeyTab // Tab is a special keybinding for switching between panes.
+	KeySubmit
 
-	// SubmitName is a special keybinding for submitting the name of a new instance.
-	KeySubmitName
+	KeyTab // Tab is a special keybinding for switching between panes.
+	KeySubmitName // SubmitName is a special keybinding for submitting the name of a new instance.
+
+	KeyPause
+	KeyResume
 )
 
 // GlobalKeyStringsMap is a global, immutable map string to keybinding.
@@ -32,9 +35,10 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"n":     KeyNew,
 	"d":     KeyKill,
 	"q":     KeyQuit,
-	"r":     KeyReview,
-	"p":     KeyPush,
 	"tab":   KeyTab,
+	"p":     KeyPause,
+	"r":     KeyResume,
+	"s":     KeySubmit,
 }
 
 // GlobalkeyBindings is a global, immutable map of KeyName tot keybinding.
@@ -49,7 +53,7 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 	),
 	KeyEnter: key.NewBinding(
 		key.WithKeys("enter", "o"),
-		key.WithHelp("o", "open"),
+		key.WithHelp("⏎/o", "open"),
 	),
 	KeyNew: key.NewBinding(
 		key.WithKeys("n"),
@@ -63,18 +67,25 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 		key.WithKeys("q"),
 		key.WithHelp("q", "quit"),
 	),
-	KeyReview: key.NewBinding(
-		key.WithKeys("r"),
-		key.WithHelp("r", "review"),
+	KeySubmit: key.NewBinding(
+		key.WithKeys("s"),
+		key.WithHelp("s", "submit"),
 	),
-	KeyPush: key.NewBinding(
+	KeyPause: key.NewBinding(
 		key.WithKeys("p"),
-		key.WithHelp("p", "push branch"),
+		key.WithHelp("p", "pause"),
 	),
 	KeyTab: key.NewBinding(
 		key.WithKeys("tab"),
 		key.WithHelp("tab", "switch tab"),
 	),
+	KeyResume: key.NewBinding(
+		key.WithKeys("r"),
+		key.WithHelp("r", "resume"),
+	),
+	
+	// -- Special keybindings --
+	
 	KeySubmitName: key.NewBinding(
 		key.WithKeys("enter"),
 		key.WithHelp("enter", "submit name"),

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"claude-squad/config"
 	"claude-squad/logger"
 	"claude-squad/session"
+	"claude-squad/session/git"
+	"claude-squad/session/tmux"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -39,6 +41,17 @@ var (
 					return fmt.Errorf("failed to reset storage: %w", err)
 				}
 				fmt.Println("Storage has been reset successfully")
+
+				if err := tmux.CleanupSessions(); err != nil {
+					return fmt.Errorf("failed to cleanup tmux sessions: %w", err)
+				}
+				fmt.Println("Tmux sessions have been cleaned up")
+
+				if err := git.CleanupWorktrees(); err != nil {
+					return fmt.Errorf("failed to cleanup worktrees: %w", err)
+				}
+				fmt.Println("Worktrees have been cleaned up")
+
 				return nil
 			}
 

--- a/session/git/util.go
+++ b/session/git/util.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"fmt"
+	"os/exec"
 	"regexp"
 	"strings"
 )
@@ -28,4 +30,20 @@ func sanitizeBranchName(s string) string {
 	s = strings.Trim(s, "-/")
 	
 	return s
+}
+
+// checkGHCLI checks if GitHub CLI is installed and configured
+func checkGHCLI() error {
+	// Check if gh is installed
+	if _, err := exec.LookPath("gh"); err != nil {
+		return fmt.Errorf("GitHub CLI (gh) is not installed. Please install it first")
+	}
+
+	// Check if gh is authenticated
+	cmd := exec.Command("gh", "auth", "status")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("GitHub CLI is not configured. Please run 'gh auth login' first")
+	}
+
+	return nil
 }

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -1,15 +1,20 @@
 package git
 
 import (
+	"claude-squad/config"
 	"fmt"
-	"io"
-	"os"
-	"os/exec"
 	"path/filepath"
-
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
+	"time"
 )
+
+func getWorktreeDirectory() (string, error) {
+	configDir, err := config.GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(configDir, "worktrees"), nil
+}
 
 // GitWorktree manages git worktree operations for a session
 type GitWorktree struct {
@@ -21,209 +26,37 @@ type GitWorktree struct {
 	sessionName string
 	// Branch name for the worktree
 	branchName string
+	// Whether the worktree is checked out
+	checkedOut bool
 }
 
 // NewGitWorktree creates a new GitWorktree instance
-func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, branchname string) {
-	branchName := fmt.Sprintf("session-%s", sessionName)
+func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, branchname string, err error) {
+	sanitizedName := sanitizeBranchName(sessionName)
+	branchName := fmt.Sprintf("session/%s", sanitizedName)
+
+	// Convert repoPath to absolute path
+	absPath, err := filepath.Abs(repoPath)
+	if err != nil {
+		// If we can't get absolute path, use original path as fallback
+		absPath = repoPath
+	}
+
+	worktreeDir, err := getWorktreeDirectory()
+	if err != nil {
+		return nil, "", err
+	}
+
+	worktreePath := filepath.Join(worktreeDir, sanitizedName)
+	worktreePath = worktreePath + "_" + fmt.Sprintf("%x", time.Now().UnixNano())
+	
 	return &GitWorktree{
-		repoPath:     repoPath,
+		repoPath:     absPath,
 		sessionName:  sessionName,
 		branchName:   branchName,
-		worktreePath: filepath.Join(filepath.Dir(repoPath), fmt.Sprintf("worktree-%s", sessionName)),
-	}, branchName
-}
-
-// runGitCommand executes a git command and returns any error
-func (g *GitWorktree) runGitCommand(args ...string) error {
-	baseArgs := []string{"-C", g.repoPath}
-	cmd := exec.Command("git", append(baseArgs, args...)...)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git command failed: %s (%w)", output, err)
-	}
-	return nil
-}
-
-// Setup creates a new worktree for the session
-func (g *GitWorktree) Setup() error {
-	// Prevent accidental overwrites
-	if _, err := os.Stat(g.worktreePath); !os.IsNotExist(err) {
-		return fmt.Errorf("worktree directory already exists at %s", g.worktreePath)
-	}
-
-	// Open the repository
-	repo, err := git.PlainOpen(g.repoPath)
-	if err != nil {
-		return fmt.Errorf("failed to open repository: %w", err)
-	}
-
-	// Get current HEAD reference
-	ref, err := repo.Head()
-	if err != nil {
-		return fmt.Errorf("failed to get HEAD reference: %w", err)
-	}
-
-	// Clean up any existing branch or reference
-	if err := g.cleanupExistingBranch(repo); err != nil {
-		return fmt.Errorf("failed to cleanup existing branch: %w", err)
-	}
-
-	// Create a new worktree using git command
-	if err := g.runGitCommand("worktree", "add", "-b", g.branchName, g.worktreePath, ref.Hash().String()); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// copyDir recursively copies a directory tree
-func (g *GitWorktree) copyDir(src string, dst string) error {
-	si, err := os.Stat(src)
-	if err != nil {
-		return fmt.Errorf("error getting source directory info for %s: %w", src, err)
-	}
-
-	if err := os.MkdirAll(dst, si.Mode()); err != nil {
-		return fmt.Errorf("error creating destination directory %s: %w", dst, err)
-	}
-
-	entries, err := os.ReadDir(src)
-	if err != nil {
-		return fmt.Errorf("error reading source directory %s: %w", src, err)
-	}
-
-	for _, entry := range entries {
-		srcPath := filepath.Join(src, entry.Name())
-		dstPath := filepath.Join(dst, entry.Name())
-
-		if entry.IsDir() {
-			if err := g.copyDir(srcPath, dstPath); err != nil {
-				return err
-			}
-		} else {
-			if err := g.copyFile(srcPath, dstPath); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// copyFile copies a single file using io.Copy for efficient streaming
-func (g *GitWorktree) copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return fmt.Errorf("error opening source file %s: %w", src, err)
-	}
-	defer in.Close()
-
-	si, err := in.Stat()
-	if err != nil {
-		return fmt.Errorf("error getting source file info for %s: %w", src, err)
-	}
-
-	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, si.Mode())
-	if err != nil {
-		return fmt.Errorf("error creating destination file %s: %w", dst, err)
-	}
-	defer func() {
-		if cerr := out.Close(); cerr != nil {
-			err = fmt.Errorf("error closing destination file %s: %w", dst, cerr)
-		}
-	}()
-
-	if _, err := io.Copy(out, in); err != nil {
-		return fmt.Errorf("error copying data from %s to %s: %w", src, dst, err)
-	}
-
-	return nil
-}
-
-// cleanupExistingBranch performs a thorough cleanup of any existing branch or reference
-func (g *GitWorktree) cleanupExistingBranch(repo *git.Repository) error {
-	branchRef := plumbing.NewBranchReferenceName(g.branchName)
-
-	// Try to remove the branch reference
-	if err := repo.Storer.RemoveReference(branchRef); err != nil && err != plumbing.ErrReferenceNotFound {
-		return fmt.Errorf("failed to remove branch reference %s: %w", g.branchName, err)
-	}
-
-	// Remove any worktree-specific references
-	worktreeRef := plumbing.NewReferenceFromStrings(
-		fmt.Sprintf("worktrees/%s/HEAD", g.branchName),
-		"",
-	)
-	if err := repo.Storer.RemoveReference(worktreeRef.Name()); err != nil && err != plumbing.ErrReferenceNotFound {
-		return fmt.Errorf("failed to remove worktree reference for %s: %w", g.branchName, err)
-	}
-
-	// Clean up configuration entries
-	cfg, err := repo.Config()
-	if err != nil {
-		return fmt.Errorf("failed to get repository config: %w", err)
-	}
-
-	delete(cfg.Branches, g.branchName)
-	worktreeSection := fmt.Sprintf("worktree.%s", g.branchName)
-	cfg.Raw.RemoveSection(worktreeSection)
-
-	if err := repo.Storer.SetConfig(cfg); err != nil {
-		return fmt.Errorf("failed to update repository config after removing branch %s: %w", g.branchName, err)
-	}
-
-	return nil
-}
-
-// Cleanup removes the worktree and associated branch
-func (g *GitWorktree) Cleanup() error {
-	var errs []error
-
-	// Remove the worktree using git command
-	if err := g.runGitCommand("worktree", "remove", "-f", g.worktreePath); err != nil {
-		errs = append(errs, err)
-	}
-
-	// Open the repository for branch cleanup
-	repo, err := git.PlainOpen(g.repoPath)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("failed to open repository for cleanup: %w", err))
-		return g.combineErrors(errs)
-	}
-
-	branchRef := plumbing.NewBranchReferenceName(g.branchName)
-
-	// Check if branch exists before attempting removal
-	if _, err := repo.Reference(branchRef, false); err == nil {
-		if err := repo.Storer.RemoveReference(branchRef); err != nil {
-			errs = append(errs, fmt.Errorf("failed to remove branch %s: %w", g.branchName, err))
-		}
-	} else if err != plumbing.ErrReferenceNotFound {
-		errs = append(errs, fmt.Errorf("error checking branch %s existence: %w", g.branchName, err))
-	}
-
-	// Prune the worktree to clean up any remaining references
-	if err := g.runGitCommand("worktree", "prune"); err != nil {
-		errs = append(errs, err)
-	}
-
-	return g.combineErrors(errs)
-}
-
-// combineErrors combines multiple errors into a single error
-func (g *GitWorktree) combineErrors(errs []error) error {
-	if len(errs) == 0 {
-		return nil
-	}
-	if len(errs) == 1 {
-		return errs[0]
-	}
-
-	errMsg := "multiple errors occurred:"
-	for _, err := range errs {
-		errMsg += "\n  - " + err.Error()
-	}
-	return fmt.Errorf(errMsg)
+		worktreePath: worktreePath,
+		checkedOut:   false,
+	}, branchName, nil
 }
 
 // GetWorktreePath returns the path to the worktree
@@ -236,44 +69,7 @@ func (g *GitWorktree) GetBranchName() string {
 	return g.branchName
 }
 
-// PushChanges commits and pushes changes in the worktree to the remote branch
-func (g *GitWorktree) PushChanges(commitMessage string) error {
-	if err := CheckGHCLI(); err != nil {
-		return err
-	}
-
-	// Stage all changes
-	if err := g.runGitCommand("-C", g.worktreePath, "add", "."); err != nil {
-		return fmt.Errorf("failed to stage changes: %w", err)
-	}
-
-	// Create commit
-	if err := g.runGitCommand("-C", g.worktreePath, "commit", "-m", commitMessage); err != nil {
-		return fmt.Errorf("failed to commit changes: %w", err)
-	}
-
-	// Push changes using gh cli to handle authentication
-	cmd := exec.Command("gh", "repo", "sync", "-b", g.branchName)
-	cmd.Dir = g.worktreePath
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to push changes: %s (%w)", output, err)
-	}
-
-	return nil
-}
-
-// CheckGHCLI checks if GitHub CLI is installed and configured
-func CheckGHCLI() error {
-	// Check if gh is installed
-	if _, err := exec.LookPath("gh"); err != nil {
-		return fmt.Errorf("GitHub CLI (gh) is not installed. Please install it first")
-	}
-
-	// Check if gh is authenticated
-	cmd := exec.Command("gh", "auth", "status")
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("GitHub CLI is not configured. Please run 'gh auth login' first")
-	}
-
-	return nil
+// GetRepoPath returns the path to the repository
+func (g *GitWorktree) GetRepoPath() string {
+	return g.repoPath
 }

--- a/session/git/worktree_branch.go
+++ b/session/git/worktree_branch.go
@@ -1,0 +1,59 @@
+package git
+
+import (
+	"fmt"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// cleanupExistingBranch performs a thorough cleanup of any existing branch or reference
+func (g *GitWorktree) cleanupExistingBranch(repo *git.Repository) error {
+	branchRef := plumbing.NewBranchReferenceName(g.branchName)
+
+	// Try to remove the branch reference
+	if err := repo.Storer.RemoveReference(branchRef); err != nil && err != plumbing.ErrReferenceNotFound {
+		return fmt.Errorf("failed to remove branch reference %s: %w", g.branchName, err)
+	}
+
+	// Remove any worktree-specific references
+	worktreeRef := plumbing.NewReferenceFromStrings(
+		fmt.Sprintf("worktrees/%s/HEAD", g.branchName),
+		"",
+	)
+	if err := repo.Storer.RemoveReference(worktreeRef.Name()); err != nil && err != plumbing.ErrReferenceNotFound {
+		return fmt.Errorf("failed to remove worktree reference for %s: %w", g.branchName, err)
+	}
+
+	// Clean up configuration entries
+	cfg, err := repo.Config()
+	if err != nil {
+		return fmt.Errorf("failed to get repository config: %w", err)
+	}
+
+	delete(cfg.Branches, g.branchName)
+	worktreeSection := fmt.Sprintf("worktree.%s", g.branchName)
+	cfg.Raw.RemoveSection(worktreeSection)
+
+	if err := repo.Storer.SetConfig(cfg); err != nil {
+		return fmt.Errorf("failed to update repository config after removing branch %s: %w", g.branchName, err)
+	}
+
+	return nil
+}
+
+// combineErrors combines multiple errors into a single error
+func (g *GitWorktree) combineErrors(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+
+	errMsg := "multiple errors occurred:"
+	for _, err := range errs {
+		errMsg += "\n  - " + err.Error()
+	}
+	return fmt.Errorf(errMsg)
+} 

--- a/session/git/worktree_fs.go
+++ b/session/git/worktree_fs.go
@@ -1,0 +1,72 @@
+package git
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// copyDir recursively copies a directory tree
+func (g *GitWorktree) copyDir(src string, dst string) error {
+	si, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("error getting source directory info for %s: %w", src, err)
+	}
+
+	if err := os.MkdirAll(dst, si.Mode()); err != nil {
+		return fmt.Errorf("error creating destination directory %s: %w", dst, err)
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("error reading source directory %s: %w", src, err)
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			if err := g.copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			if err := g.copyFile(srcPath, dstPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// copyFile copies a single file using io.Copy for efficient streaming
+func (g *GitWorktree) copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("error opening source file %s: %w", src, err)
+	}
+	defer in.Close()
+
+	si, err := in.Stat()
+	if err != nil {
+		return fmt.Errorf("error getting source file info for %s: %w", src, err)
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, si.Mode())
+	if err != nil {
+		return fmt.Errorf("error creating destination file %s: %w", dst, err)
+	}
+	defer func() {
+		if cerr := out.Close(); cerr != nil {
+			err = fmt.Errorf("error closing destination file %s: %w", dst, cerr)
+		}
+	}()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("error copying data from %s to %s: %w", src, dst, err)
+	}
+
+	return nil
+} 

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -1,0 +1,93 @@
+package git
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+// runGitCommand executes a git command and returns any error
+func (g *GitWorktree) runGitCommand(path string, args ...string) (string, error) {
+	baseArgs := []string{"-C", path}
+	cmd := exec.Command("git", append(baseArgs, args...)...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git command failed: %s (%w)", output, err)
+	}
+
+	return string(output), nil
+}
+
+// PushChanges commits and pushes changes in the worktree to the remote branch
+func (g *GitWorktree) PushChanges(commitMessage string) error {
+	if err := checkGHCLI(); err != nil {
+		return err
+	}
+
+	// Check if there are any changes to commit
+	isDirty, err := g.IsDirty()
+	if err != nil {
+		return fmt.Errorf("failed to check for changes: %w", err)
+	}
+
+	if isDirty {
+		// Stage all changes
+		if _, err := g.runGitCommand(g.worktreePath, "add", "."); err != nil {
+			log.Println(err)
+			return fmt.Errorf("failed to stage changes: %w", err)
+		}
+
+		// Create commit
+		if _, err := g.runGitCommand(g.worktreePath, "commit", "-m", commitMessage); err != nil {
+			log.Println(err)
+			return fmt.Errorf("failed to commit changes: %w", err)
+		}
+	}
+
+	// First push the branch to remote to ensure it exists
+	pushCmd := exec.Command("gh", "repo", "sync", "--source", "-b", g.branchName)
+	pushCmd.Dir = g.worktreePath
+	if err := pushCmd.Run(); err != nil {
+		// If sync fails, try creating the branch on remote first
+		gitPushCmd := exec.Command("git", "push", "-u", "origin", g.branchName)
+		gitPushCmd.Dir = g.worktreePath
+		if pushOutput, pushErr := gitPushCmd.CombinedOutput(); pushErr != nil {
+			log.Println(pushErr)
+			return fmt.Errorf("failed to push branch: %s (%w)", pushOutput, pushErr)
+		}
+	}
+
+	// Now sync with remote
+	syncCmd := exec.Command("gh", "repo", "sync", "-b", g.branchName)
+	syncCmd.Dir = g.worktreePath
+	if output, err := syncCmd.CombinedOutput(); err != nil {
+		log.Println(err)
+		return fmt.Errorf("failed to sync changes: %s (%w)", output, err)
+	}
+
+	return nil
+}
+
+// IsDirty checks if the worktree has uncommitted changes
+func (g *GitWorktree) IsDirty() (bool, error) {
+	output, err := g.runGitCommand(g.worktreePath, "status", "--porcelain")
+	if err != nil {
+		return false, fmt.Errorf("failed to check worktree status: %w", err)
+	}
+	return len(output) > 0, nil
+}
+
+// IsBranchCheckedOut checks if the instance branch is currently checked out
+func (g *GitWorktree) IsBranchCheckedOut() (bool, error) {
+	if g.checkedOut {
+		return true, nil
+	} else {
+		output, err := g.runGitCommand(g.repoPath, "branch", "--show-current")
+		if err != nil {
+			return false, fmt.Errorf("failed to get current branch: %w", err)
+		}
+		return strings.TrimSpace(string(output)) == g.branchName, nil
+	}
+} 

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -1,0 +1,222 @@
+package git
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// Setup creates a new worktree for the session
+func (g *GitWorktree) Setup() error {
+	// Check if branch exists first
+	repo, err := git.PlainOpen(g.repoPath)
+	if err != nil {
+		return fmt.Errorf("failed to open repository: %w", err)
+	}
+
+	branchRef := plumbing.NewBranchReferenceName(g.branchName)
+	if _, err := repo.Reference(branchRef, false); err == nil {
+		// Branch exists, use SetupFromExistingBranch
+		return g.SetupFromExistingBranch()
+	}
+
+	// Branch doesn't exist, create new worktree from HEAD
+	return g.SetupNewWorktree()
+}
+
+// SetupFromExistingBranch creates a worktree from an existing branch
+func (g *GitWorktree) SetupFromExistingBranch() error {
+	// Ensure worktrees directory exists
+	worktreesDir := filepath.Join(g.repoPath, "worktrees")
+	if err := os.MkdirAll(worktreesDir, 0755); err != nil {
+		return fmt.Errorf("failed to create worktrees directory: %w", err)
+	}
+
+	// Clean up any existing worktree first
+	if _, err := g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath); err != nil {
+		// Ignore errors here as the worktree might not exist
+	}
+
+	// Create a new worktree from the existing branch
+	if _, err := g.runGitCommand(g.repoPath, "worktree", "add", g.worktreePath, g.branchName); err != nil {
+		return fmt.Errorf("failed to create worktree from branch %s: %w", g.branchName, err)
+	}
+
+	g.checkedOut = true
+	return nil
+}
+
+// SetupNewWorktree creates a new worktree from HEAD
+func (g *GitWorktree) SetupNewWorktree() error {
+	// Ensure worktrees directory exists
+	worktreesDir := filepath.Join(g.repoPath, "worktrees")
+	if err := os.MkdirAll(worktreesDir, 0755); err != nil {
+		return fmt.Errorf("failed to create worktrees directory: %w", err)
+	}
+
+	// Clean up any existing worktree first
+	if _, err := g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath); err != nil {
+		// Ignore errors here as the worktree might not exist
+	}
+
+	// Open the repository
+	repo, err := git.PlainOpen(g.repoPath)
+	if err != nil {
+		return fmt.Errorf("failed to open repository: %w", err)
+	}
+
+	// Clean up any existing branch or reference
+	if err := g.cleanupExistingBranch(repo); err != nil {
+		return fmt.Errorf("failed to cleanup existing branch: %w", err)
+	}
+
+	// Get current branch name
+	output, err := g.runGitCommand(g.repoPath, "branch", "--show-current")
+	if err != nil {
+		return fmt.Errorf("failed to get current branch: %w", err)
+	}
+	currentBranch := strings.TrimSpace(string(output))
+	if currentBranch == "" {
+		return fmt.Errorf("not currently on any branch")
+	}
+
+	// Create a new worktree from the current branch
+	if _, err := g.runGitCommand(g.repoPath, "worktree", "add", "-b", g.branchName, g.worktreePath, currentBranch); err != nil {
+		return fmt.Errorf("failed to create worktree from branch %s: %w", currentBranch, err)
+	}
+
+	g.checkedOut = true
+	return nil
+}
+
+// Cleanup removes the worktree and associated branch
+func (g *GitWorktree) Cleanup() error {
+	var errs []error
+
+	// Check if worktree path exists before attempting removal
+	if _, err := os.Stat(g.worktreePath); err == nil {
+		// Remove the worktree using git command
+		if _, err := g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath); err != nil {
+			errs = append(errs, err)
+		}
+	} else if !os.IsNotExist(err) {
+		// Only append error if it's not a "not exists" error
+		errs = append(errs, fmt.Errorf("failed to check worktree path: %w", err))
+	}
+
+	// Open the repository for branch cleanup
+	repo, err := git.PlainOpen(g.repoPath)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("failed to open repository for cleanup: %w", err))
+		return g.combineErrors(errs)
+	}
+
+	branchRef := plumbing.NewBranchReferenceName(g.branchName)
+
+	// Check if branch exists before attempting removal
+	if _, err := repo.Reference(branchRef, false); err == nil {
+		if err := repo.Storer.RemoveReference(branchRef); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove branch %s: %w", g.branchName, err))
+		}
+	} else if err != plumbing.ErrReferenceNotFound {
+		errs = append(errs, fmt.Errorf("error checking branch %s existence: %w", g.branchName, err))
+	}
+
+	// Prune the worktree to clean up any remaining references
+	if err := g.Prune(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return g.combineErrors(errs)
+	}
+
+	g.checkedOut = false
+	return nil
+}
+
+// Remove removes the worktree but keeps the branch
+func (g *GitWorktree) Remove() error {
+	// Remove the worktree using git command
+	if _, err := g.runGitCommand(g.repoPath, "worktree", "remove", "-f", g.worktreePath); err != nil {
+		return fmt.Errorf("failed to remove worktree: %w", err)
+	}
+
+	g.checkedOut = false
+	return nil
+}
+
+// Prune removes all working tree administrative files and directories
+func (g *GitWorktree) Prune() error {
+	if _, err := g.runGitCommand(g.repoPath, "worktree", "prune"); err != nil {
+		return fmt.Errorf("failed to prune worktrees: %w", err)
+	}
+	return nil
+}
+
+// CleanupWorktrees removes all worktrees and their associated branches
+func CleanupWorktrees() error {
+	worktreesDir, err := getWorktreeDirectory()
+	if err != nil {
+		return fmt.Errorf("failed to get worktree directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(worktreesDir)
+	if err != nil {
+		return fmt.Errorf("failed to read worktree directory: %w", err)
+	}
+
+	// Get a list of all branches associated with worktrees
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	// Parse the output to extract branch names
+	worktreeBranches := make(map[string]string)
+	currentWorktree := ""
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "worktree ") {
+			currentWorktree = strings.TrimPrefix(line, "worktree ")
+		} else if strings.HasPrefix(line, "branch ") {
+			branchPath := strings.TrimPrefix(line, "branch ")
+			// Extract branch name from refs/heads/branch-name
+			branchName := strings.TrimPrefix(branchPath, "refs/heads/")
+			if currentWorktree != "" {
+				worktreeBranches[currentWorktree] = branchName
+			}
+		}
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			worktreePath := filepath.Join(worktreesDir, entry.Name())
+			
+			// Delete the branch associated with this worktree if found
+			for path, branch := range worktreeBranches {
+				if strings.Contains(path, entry.Name()) {
+					// Delete the branch
+					deleteCmd := exec.Command("git", "branch", "-D", branch)
+					if err := deleteCmd.Run(); err != nil {
+						// Log the error but continue with other worktrees
+						log.Printf("failed to delete branch %s: %v", branch, err)
+					}
+					break
+				}
+			}
+			
+			// Remove the worktree directory
+			os.RemoveAll(worktreePath)
+		}
+	}
+	
+	return nil
+} 

--- a/session/storage.go
+++ b/session/storage.go
@@ -9,6 +9,14 @@ import (
 	"time"
 )
 
+// GitWorktreeData represents the serializable data of a GitWorktree
+type GitWorktreeData struct {
+	RepoPath     string
+	WorktreePath string
+	SessionName  string
+	BranchName   string
+}
+
 // InstanceData represents the serializable data of an Instance
 type InstanceData struct {
 	Title     string
@@ -20,6 +28,7 @@ type InstanceData struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	Program   string
+	Worktree  GitWorktreeData
 }
 
 // Storage handles saving and loading instances

--- a/ui/list.go
+++ b/ui/list.go
@@ -12,9 +12,13 @@ import (
 )
 
 const readyIcon = "● "
+const pausedIcon = "⏸ "
 
 var readyStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#51bd73", Dark: "#51bd73"})
+
+var pausedStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.AdaptiveColor{Light: "#888888", Dark: "#888888"})
 
 var spinnerStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#dddddd"})
@@ -110,15 +114,18 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool) s
 
 	// add spinner next to title if it's running
 	var join string
+	var title = fmt.Sprintf("%s %s", prefix, i.Title)
 	switch i.Status {
 	case session.Running:
 		join = fmt.Sprintf("%s ", r.spinner.View())
 	case session.Ready:
 		join = readyStyle.Render(readyIcon)
+	case session.Paused:
+		join = pausedStyle.Render(pausedIcon)
 	default:
 	}
 
-	title := titleS.Render(
+	title = titleS.Render(
 		lipgloss.JoinHorizontal(
 			lipgloss.Left,
 			lipgloss.Place(r.width-3, 1, lipgloss.Left, lipgloss.Center, fmt.Sprintf("%s %s", prefix, i.Title)),

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -4,6 +4,8 @@ import (
 	"claude-squad/keys"
 	"strings"
 
+	"claude-squad/session"
+
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -22,26 +24,84 @@ var sepStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
 	Dark:  "#3C3C3C",
 })
 
+var actionGroupStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("99"))
+
 var separator = "  •  "
+var verticalSeparator = "  │  "
 
 var menuStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.Color("205"))
 
+// MenuState represents different states the menu can be in
+type MenuState int
+
+const (
+	StateDefault MenuState = iota
+	StateNewInstance
+)
+
 type Menu struct {
 	options       []keys.KeyName
 	height, width int
+	state        MenuState
+	instance     *session.Instance
 }
 
-var StartMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyKill, keys.KeyEnter, keys.KeyTab, keys.KeyPush, keys.KeyQuit}
+var defaultMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyQuit}
+var newInstanceMenuOptions = []keys.KeyName{keys.KeySubmitName}
 
 func NewMenu() *Menu {
 	return &Menu{
-		options: StartMenuOptions,
+		options: defaultMenuOptions,
+		state:   StateDefault,
 	}
 }
 
-func (m *Menu) SetOptions(options []keys.KeyName) {
-	m.options = options
+// SetState updates the menu state and options accordingly
+func (m *Menu) SetState(state MenuState) {
+	m.state = state
+	m.updateOptions()
+}
+
+// SetInstance updates the current instance and refreshes menu options
+func (m *Menu) SetInstance(instance *session.Instance) {
+	m.instance = instance
+	if m.state == StateDefault {
+		m.updateOptions()
+	}
+}
+
+// updateOptions updates the menu options based on current state and instance
+func (m *Menu) updateOptions() {
+	switch m.state {
+	case StateNewInstance:
+		m.options = newInstanceMenuOptions
+	case StateDefault:
+		if m.instance == nil {
+			m.options = defaultMenuOptions
+			return
+		}
+
+		// Instance management group
+		options := []keys.KeyName{keys.KeyNew, keys.KeyKill}
+		
+		// Action group
+		actionGroup := []keys.KeyName{keys.KeyEnter, keys.KeySubmit}
+		if m.instance.Status == session.Paused {
+			actionGroup = append(actionGroup, keys.KeyResume)
+		} else {
+			actionGroup = append(actionGroup, keys.KeyPause)
+		}
+		
+		// System group
+		systemGroup := []keys.KeyName{keys.KeyTab, keys.KeyQuit}
+
+		// Combine all groups
+		options = append(options, actionGroup...)
+		options = append(options, systemGroup...)
+		
+		m.options = options
+	}
 }
 
 // SetSize sets the width of the window. The menu will be centered horizontally within this width.
@@ -52,13 +112,46 @@ func (m *Menu) SetSize(width, height int) {
 
 func (m *Menu) String() string {
 	var s strings.Builder
+	
+	// Define group boundaries
+	groups := []struct {
+		start int
+		end   int
+	}{
+		{0, 2},    // Instance management group (n, d)
+		{2, 5},    // Action group (enter, submit, pause/resume)
+		{5, 7},    // System group (tab, q)
+	}
+	
 	for i, k := range m.options {
 		binding := keys.GlobalkeyBindings[k]
-		s.WriteString(keyStyle.Render(binding.Help().Key))
-		s.WriteString(" ")
-		s.WriteString(descStyle.Render(binding.Help().Desc))
+		
+		// Check if we're in the action group (middle group)
+		inActionGroup := i >= groups[1].start && i < groups[1].end
+		
+		if inActionGroup {
+			s.WriteString(actionGroupStyle.Render(binding.Help().Key))
+			s.WriteString(" ")
+			s.WriteString(actionGroupStyle.Render(binding.Help().Desc))
+		} else {
+			s.WriteString(keyStyle.Render(binding.Help().Key))
+			s.WriteString(" ")
+			s.WriteString(descStyle.Render(binding.Help().Desc))
+		}
+		
+		// Add appropriate separator
 		if i != len(m.options)-1 {
-			s.WriteString(sepStyle.Render(separator))
+			isGroupEnd := false
+			for _, group := range groups {
+				if i == group.end-1 {
+					s.WriteString(sepStyle.Render(verticalSeparator))
+					isGroupEnd = true
+					break
+				}
+			}
+			if !isGroupEnd {
+				s.WriteString(sepStyle.Render(separator))
+			}
 		}
 	}
 


### PR DESCRIPTION
This change introduces pause/resume functionality for managed instances so that the user can checkout/modify the instance's code.

- Added pause/resume with a new Paused state and copy to clipboard when pausing
- Improved UI with menu state management and a paused state icon.
- Updated tmux behavior: detach key is now Ctrl+q
- `--reset` now cleans up tmux sessions and worktrees

https://github.com/user-attachments/assets/abb6c32b-d92c-4707-a085-3143fe7a1591