### PR TITLE
app: allow for quitting while paused

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -180,7 +180,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.state = stateDefault
 				m.menu.SetState(ui.StateDefault)
 			}()
-			if err := instance.Start(false); err != nil {
+			if err := instance.Start(true); err != nil {
 				m.list.Kill()
 				return m.showErrorMessageForShortTime(err)
 			}
@@ -310,7 +310,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if err := selected.Resume(); err != nil {
 			return m.showErrorMessageForShortTime(err)
 		}
-		return m.updatePreview()
+		return m, tea.WindowSize()
 	case keys.KeyEnter:
 		if m.list.NumInstances() == 0 {
 			return m, nil

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -26,8 +26,15 @@ type GitWorktree struct {
 	sessionName string
 	// Branch name for the worktree
 	branchName string
-	// Whether the worktree is checked out
-	checkedOut bool
+}
+
+func NewGitWorktreeFromStorage(repoPath string, worktreePath string, sessionName string, branchName string) *GitWorktree {
+	return &GitWorktree{
+		repoPath:     repoPath,
+		worktreePath: worktreePath,
+		sessionName:  sessionName,
+		branchName:   branchName,
+	}
 }
 
 // NewGitWorktree creates a new GitWorktree instance
@@ -55,7 +62,6 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 		sessionName:  sessionName,
 		branchName:   branchName,
 		worktreePath: worktreePath,
-		checkedOut:   false,
 	}, branchName, nil
 }
 

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -81,13 +81,9 @@ func (g *GitWorktree) IsDirty() (bool, error) {
 
 // IsBranchCheckedOut checks if the instance branch is currently checked out
 func (g *GitWorktree) IsBranchCheckedOut() (bool, error) {
-	if g.checkedOut {
-		return true, nil
-	} else {
-		output, err := g.runGitCommand(g.repoPath, "branch", "--show-current")
-		if err != nil {
-			return false, fmt.Errorf("failed to get current branch: %w", err)
-		}
-		return strings.TrimSpace(string(output)) == g.branchName, nil
+	output, err := g.runGitCommand(g.repoPath, "branch", "--show-current")
+	if err != nil {
+		return false, fmt.Errorf("failed to get current branch: %w", err)
 	}
+	return strings.TrimSpace(string(output)) == g.branchName, nil
 }

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -46,7 +46,6 @@ func (g *GitWorktree) SetupFromExistingBranch() error {
 		return fmt.Errorf("failed to create worktree from branch %s: %w", g.branchName, err)
 	}
 
-	g.checkedOut = true
 	return nil
 }
 
@@ -87,7 +86,6 @@ func (g *GitWorktree) SetupNewWorktree() error {
 		return fmt.Errorf("failed to create worktree from branch %s: %w", currentBranch, err)
 	}
 
-	g.checkedOut = true
 	return nil
 }
 
@@ -133,7 +131,6 @@ func (g *GitWorktree) Cleanup() error {
 		return g.combineErrors(errs)
 	}
 
-	g.checkedOut = false
 	return nil
 }
 
@@ -144,7 +141,6 @@ func (g *GitWorktree) Remove() error {
 		return fmt.Errorf("failed to remove worktree: %w", err)
 	}
 
-	g.checkedOut = false
 	return nil
 }
 

--- a/ui/list.go
+++ b/ui/list.go
@@ -68,7 +68,7 @@ func (l *List) SetSize(width, height int) {
 // width and height.
 func (l *List) SetSessionPreviewSize(width, height int) (err error) {
 	for i, item := range l.items {
-		if !item.Started() {
+		if !item.Started() || item.Paused() {
 			continue
 		}
 


### PR DESCRIPTION
Now, you can quit the program while instances are paused and reopen the program to view paused instances. Basically, we can load/store sessions that are in the paused state. Previously, we couldn't.