### PR TITLE
ui/list: show repo name when multiple repos are used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea
 .aider*
-
+claude-squad

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -3,6 +3,7 @@ package git
 import (
 	"claude-squad/config"
 	"fmt"
+	"log"
 	"path/filepath"
 	"time"
 )
@@ -45,6 +46,7 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 	// Convert repoPath to absolute path
 	absPath, err := filepath.Abs(repoPath)
 	if err != nil {
+		log.Printf("git worktree path abs error, falling back to repoPath %s: %s", repoPath, err)
 		// If we can't get absolute path, use original path as fallback
 		absPath = repoPath
 	}
@@ -78,4 +80,9 @@ func (g *GitWorktree) GetBranchName() string {
 // GetRepoPath returns the path to the repository
 func (g *GitWorktree) GetRepoPath() string {
 	return g.repoPath
+}
+
+// GetRepoName returns the name of the repository (last part of the repoPath).
+func (g *GitWorktree) GetRepoName() string {
+	return filepath.Base(g.repoPath)
 }

--- a/session/instance.go
+++ b/session/instance.go
@@ -142,6 +142,13 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 	}, nil
 }
 
+func (i *Instance) RepoName() (string, error) {
+	if !i.started {
+		return "", fmt.Errorf("cannot get repo name for instance that has not been started")
+	}
+	return i.gitWorktree.GetRepoName(), nil
+}
+
 func (i *Instance) SetStatus(status Status) {
 	i.Status = status
 }


### PR DESCRIPTION
Now, if you open the app in two repos and create instances in both, we'll show the repo name in the instance card. When you delete instances until there's only instances for one repo, the repo name goes away.

This change does not add full support for multi repo. Some races are possible, mainly around storage. For example:

p1: make instances 1, 2, 3
p2: delete instance 1
p1: preview / state breaks for instance 1 because the tmux session and worktree are gone
p2: exit
p1: exit and saves the erroring instance 1

new process: sees erroring instance 1 when you open it because we stored that in the instances.json