### PR TITLE
app: add yolo mode

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -26,6 +26,9 @@ const (
 	// Diff keybindings
 	KeyShiftUp
 	KeyShiftDown
+
+	// AutoYes makes the claude instance tap Yes when prompted.
+	KeyAutoYes
 )
 
 // GlobalKeyStringsMap is a global, immutable map string to keybinding.
@@ -45,6 +48,7 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"p":          KeyPause,
 	"r":          KeyResume,
 	"s":          KeySubmit,
+	"y":          KeyAutoYes,
 }
 
 // GlobalkeyBindings is a global, immutable map of KeyName tot keybinding.
@@ -96,6 +100,10 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 	KeyResume: key.NewBinding(
 		key.WithKeys("r"),
 		key.WithHelp("r", "resume"),
+	),
+	KeyAutoYes: key.NewBinding(
+		key.WithKeys("y"),
+		key.WithHelp("y", "auto yes"),
 	),
 
 	// -- Special keybindings --

--- a/session/storage.go
+++ b/session/storage.go
@@ -35,6 +35,8 @@ type InstanceData struct {
 	Width     int
 	CreatedAt time.Time
 	UpdatedAt time.Time
+	AutoYes   bool
+
 	Program   string
 	Worktree  GitWorktreeData
 	DiffStats DiffStatsData

--- a/ui/list.go
+++ b/ui/list.go
@@ -132,9 +132,17 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 	default:
 	}
 
+	titleText := i.Title
+	if i.AutoYes {
+		titleText += " (yolo)"
+	}
+	widthAvail := r.width - 3 - len(prefix) - 1
+	if widthAvail > 0 && widthAvail < len(titleText) && len(titleText) >= widthAvail-3 {
+		titleText = titleText[:widthAvail-3] + "..."
+	}
 	title := titleS.Render(lipgloss.JoinHorizontal(
 		lipgloss.Left,
-		lipgloss.Place(r.width-3, 1, lipgloss.Left, lipgloss.Center, fmt.Sprintf("%s %s", prefix, i.Title)),
+		lipgloss.Place(r.width-3, 1, lipgloss.Left, lipgloss.Center, fmt.Sprintf("%s %s", prefix, titleText)),
 		" ",
 		join,
 	))

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -102,6 +102,7 @@ func (m *Menu) updateOptions() {
 		} else {
 			actionGroup = append(actionGroup, keys.KeyPause)
 		}
+		actionGroup = append(actionGroup, keys.KeyAutoYes)
 
 		// Navigation group (when in diff tab)
 		if m.isInDiffTab {
@@ -134,8 +135,8 @@ func (m *Menu) String() string {
 		end   int
 	}{
 		{0, 2}, // Instance management group (n, d)
-		{2, 5}, // Action group (enter, submit, pause/resume)
-		{5, 7}, // System group (tab, q)
+		{2, 6}, // Action group (enter, submit, pause/resume, autoyes)
+		{6, 8}, // System group (tab, q)
 	}
 
 	for i, k := range m.options {


### PR DESCRIPTION
This change introduces yolo mode. We call this "auto yes" to make it clear that, in this mode, the claude instance automatically hits yes when prompted. This is a new menu option. If yolo mode is enabled, the instance will have (yolo) next to it's name.

We check for if Yes needs to be tapped at the same time we poll for Running/Ready status. We check if the text "Do you want" is present in the claude output. We could get false positives if the users code has "Do you want" in it, but tapping enter really isn't that bad.

This change also makes sure we truncate titles if the text is too long.