### PR TITLE
daemon: introduce autoyes daemon

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,5 +30,7 @@ jobs:
           if [ -n "$(gofmt -l .)" ]; then
             echo "The following files are not formatted correctly:"
             gofmt -l .
+            echo "Fix these issues"
+            gofmt -d .
             exit 1
           fi 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Development
+
+### Lint
+```
+gofmt -d .
+```

--- a/app/app.go
+++ b/app/app.go
@@ -18,12 +18,10 @@ import (
 const GlobalInstanceLimit = 10
 
 // Run is the main entrypoint into the application.
-func Run(ctx context.Context, program string, autoYes bool) {
+func Run(ctx context.Context, program string, autoYes bool) error {
 	p := tea.NewProgram(newHome(ctx, program, autoYes), tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	_, err := p.Run()
+	return err
 }
 
 type state int
@@ -118,7 +116,7 @@ func (m *home) updateHandleWindowSizeEvent(msg tea.WindowSizeMsg) {
 
 	previewWidth, previewHeight := m.tabbedWindow.GetPreviewSize()
 	if err := m.list.SetSessionPreviewSize(previewWidth, previewHeight); err != nil {
-		log.Error(err)
+		log.ErrorLog.Print(err)
 	}
 	m.menu.SetSize(msg.Width, menuHeight)
 }
@@ -167,7 +165,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			if err := instance.UpdateDiffStats(); err != nil {
-				log.Warnf("could not update diff stats: %v", err)
+				log.WarningLog.Printf("could not update diff stats: %v", err)
 			}
 		}
 		return m, tickUpdateMetadataCmd

--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,7 @@ func LoadConfig() (*Config, error) {
 			// Create and save default config if file doesn't exist
 			defaultCfg := DefaultConfig()
 			if saveErr := SaveConfig(defaultCfg); saveErr != nil {
-				log.Errorf("Warning: failed to save default config: %v", saveErr)
+				log.ErrorLog.Printf("Warning: failed to save default config: %v", saveErr)
 			}
 			return defaultCfg, nil
 		}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"claude-squad/config"
+	"claude-squad/log"
+	"claude-squad/session"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+)
+
+var daemonPollInterval = 1 * time.Second
+
+// RunDaemon runs the daemon process which iterates over all sessions and runs AutoYes mode on them.
+// It's expected that the main process kills the daemon when the main process starts.
+func RunDaemon() error {
+	log.InfoLog.Printf("starting daemon")
+	storage, err := session.NewStorage()
+	if err != nil {
+		return fmt.Errorf("failed to initialize storage: %w", err)
+	}
+
+	instances, err := storage.LoadInstances()
+	if err != nil {
+		return fmt.Errorf("failed to load instacnes: %w", err)
+	}
+	for _, instance := range instances {
+		// Assume AutoYes is true if the daemon is running.
+		instance.AutoYes = true
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	stopCh := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTimer(daemonPollInterval)
+		for {
+			for _, instance := range instances {
+				// We only store started instances, but check anyway.
+				if instance.Started() && !instance.Paused() {
+					if _, hasPrompt := instance.HasUpdated(); hasPrompt {
+						instance.TapEnter()
+						if err := instance.UpdateDiffStats(); err != nil {
+							log.WarningLog.Printf("could not update diff stats for %s: %v", instance.Title, err)
+						}
+					}
+				}
+			}
+
+			// Handle stop before ticker.
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+
+			<-ticker.C
+
+			ticker.Reset(daemonPollInterval)
+		}
+
+	}()
+
+	// Notify on SIGINT (Ctrl+C) and SIGTERM. Save instances before
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-sigChan
+	log.InfoLog.Printf("received signal %s", sig.String())
+
+	// Stop the goroutine so we don't race.
+	close(stopCh)
+	wg.Wait()
+
+	if err := storage.SaveInstances(instances); err != nil {
+		log.ErrorLog.Printf("failed to save instances when terminating daemon: %v", err)
+	}
+	return nil
+}
+
+// LaunchDaemon launches the daemon process.
+func LaunchDaemon() error {
+	// Find the claude squad binary.
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get executable path: %w", err)
+	}
+
+	cmd := exec.Command(execPath, "--daemon")
+
+	// Detach the process from the parent
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	// Set process group to prevent signals from propagating
+	cmd.SysProcAttr = getSysProcAttr()
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start child process: %w", err)
+	}
+
+	log.InfoLog.Printf("started daemon child process with PID: %d", cmd.Process.Pid)
+
+	// Save PID to a file for later management
+	pidDir, err := config.GetConfigDir()
+	if err != nil {
+		return fmt.Errorf("failed to get config directory: %w", err)
+	}
+
+	pidFile := filepath.Join(pidDir, "daemon.pid")
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0644); err != nil {
+		return fmt.Errorf("failed to write PID file: %w", err)
+	}
+
+	// Don't wait for the child to exit, it's detached
+	return nil
+}
+
+// StopDaemon attempts to stop a running daemon process if it exists.
+func StopDaemon() error {
+	pidDir, err := config.GetConfigDir()
+	if err != nil {
+		return fmt.Errorf("failed to get config directory: %w", err)
+	}
+
+	pidFile := filepath.Join(pidDir, "daemon.pid")
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.InfoLog.Print("no daemon is running (PID file not found)")
+			return nil
+		}
+		return fmt.Errorf("failed to read PID file: %w", err)
+	}
+
+	var pid int
+	if _, err := fmt.Sscanf(string(data), "%d", &pid); err != nil {
+		return fmt.Errorf("invalid PID file format: %w", err)
+	}
+
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("failed to find daemon process: %w", err)
+	}
+
+	if err := proc.Kill(); err != nil {
+		return fmt.Errorf("failed to stop daemon process: %w", err)
+	}
+
+	// Clean up PID file
+	if err := os.Remove(pidFile); err != nil {
+		return fmt.Errorf("failed to remove PID file: %w", err)
+	}
+
+	log.InfoLog.Printf("Daemon process (PID: %d) stopped successfully", pid)
+	return nil
+}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"syscall"
+)
+
+// getSysProcAttr returns platform-specific process attributes for detaching the child process
+func getSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setsid: true, // Create a new session
+	}
+}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package daemon
+
+import (
+	"golang.org/x/sys/windows"
+	"syscall"
+)
+
+// getSysProcAttr returns platform-specific process attributes for detaching the child process
+func getSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
+	}
+}

--- a/log/log.go
+++ b/log/log.go
@@ -13,34 +13,6 @@ var (
 	ErrorLog   *log.Logger
 )
 
-func Errorf(format string, v ...interface{}) {
-	ErrorLog.Printf(format, v...)
-}
-
-func Error(v ...any) {
-	ErrorLog.Println(v...)
-}
-
-func Infof(format string, v ...interface{}) {
-	InfoLog.Printf(format, v...)
-}
-
-func Info(v ...any) {
-	InfoLog.Println(v...)
-}
-
-func Warnf(format string, v ...interface{}) {
-	WarningLog.Printf(format, v...)
-}
-
-func Warn(v ...any) {
-	WarningLog.Println(v...)
-}
-
-func Fatal(v ...any) {
-	ErrorLog.Fatal(v...)
-}
-
 var logFileName = filepath.Join(os.TempDir(), "claudesquad.log")
 
 var globalLogFile *os.File
@@ -48,7 +20,8 @@ var globalLogFile *os.File
 // Initialize should be called once at the beginning of the program to set up logging.
 // defer Close() after calling this function. It sets the go log output to the file in
 // the os temp directory.
-func Initialize() {
+
+func Initialize(daemon bool) {
 	f, err := os.OpenFile(logFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
 	if err != nil {
 		panic(fmt.Sprintf("could not open log file: %s", err))
@@ -57,9 +30,13 @@ func Initialize() {
 	// Set log format to include timestamp and file/line number
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
-	InfoLog = log.New(f, "INFO: ", log.Ldate|log.Ltime|log.Lshortfile)
-	WarningLog = log.New(f, "WARNING: ", log.Ldate|log.Ltime|log.Lshortfile)
-	ErrorLog = log.New(f, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
+	fmtS := "%s"
+	if daemon {
+		fmtS = "%s [DAEMON]"
+	}
+	InfoLog = log.New(f, fmt.Sprintf(fmtS, "INFO:"), log.Ldate|log.Ltime|log.Lshortfile)
+	WarningLog = log.New(f, fmt.Sprintf(fmtS, "WARNING:"), log.Ldate|log.Ltime|log.Lshortfile)
+	ErrorLog = log.New(f, fmt.Sprintf(fmtS, "ERROR:"), log.Ldate|log.Ltime|log.Lshortfile)
 
 	globalLogFile = f
 }

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -49,7 +49,7 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 	// Convert repoPath to absolute path
 	absPath, err := filepath.Abs(repoPath)
 	if err != nil {
-		log.Errorf("git worktree path abs error, falling back to repoPath %s: %s", repoPath, err)
+		log.ErrorLog.Printf("git worktree path abs error, falling back to repoPath %s: %s", repoPath, err)
 		// If we can't get absolute path, use original path as fallback
 		absPath = repoPath
 	}

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -35,13 +35,13 @@ func (g *GitWorktree) PushChanges(commitMessage string) error {
 	if isDirty {
 		// Stage all changes
 		if _, err := g.runGitCommand(g.worktreePath, "add", "."); err != nil {
-			log.Error(err)
+			log.ErrorLog.Print(err)
 			return fmt.Errorf("failed to stage changes: %w", err)
 		}
 
 		// Create commit
 		if _, err := g.runGitCommand(g.worktreePath, "commit", "-m", commitMessage); err != nil {
-			log.Error(err)
+			log.ErrorLog.Print(err)
 			return fmt.Errorf("failed to commit changes: %w", err)
 		}
 	}
@@ -54,7 +54,7 @@ func (g *GitWorktree) PushChanges(commitMessage string) error {
 		gitPushCmd := exec.Command("git", "push", "-u", "origin", g.branchName)
 		gitPushCmd.Dir = g.worktreePath
 		if pushOutput, pushErr := gitPushCmd.CombinedOutput(); pushErr != nil {
-			log.Error(pushErr)
+			log.ErrorLog.Print(pushErr)
 			return fmt.Errorf("failed to push branch: %s (%w)", pushOutput, pushErr)
 		}
 	}
@@ -63,7 +63,7 @@ func (g *GitWorktree) PushChanges(commitMessage string) error {
 	syncCmd := exec.Command("gh", "repo", "sync", "-b", g.branchName)
 	syncCmd.Dir = g.worktreePath
 	if output, err := syncCmd.CombinedOutput(); err != nil {
-		log.Error(err)
+		log.ErrorLog.Print(err)
 		return fmt.Errorf("failed to sync changes: %s (%w)", output, err)
 	}
 

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -199,7 +199,7 @@ func CleanupWorktrees() error {
 					deleteCmd := exec.Command("git", "branch", "-D", branch)
 					if err := deleteCmd.Run(); err != nil {
 						// Log the error but continue with other worktrees
-						log.Errorf("failed to delete branch %s: %v", branch, err)
+						log.ErrorLog.Printf("failed to delete branch %s: %v", branch, err)
 					}
 					break
 				}

--- a/session/instance.go
+++ b/session/instance.go
@@ -371,13 +371,13 @@ func (i *Instance) Pause() error {
 	// Check if there are any changes to commit
 	if dirty, err := i.gitWorktree.IsDirty(); err != nil {
 		errs = append(errs, fmt.Errorf("failed to check if worktree is dirty: %w", err))
-		log.Error(err)
+		log.ErrorLog.Print(err)
 	} else if dirty {
 		// Commit changes with timestamp
 		commitMsg := fmt.Sprintf("Update from session %s at %s (paused)", i.Title, time.Now().Format(time.RFC3339))
 		if err := i.gitWorktree.PushChanges(commitMsg); err != nil {
 			errs = append(errs, fmt.Errorf("failed to commit changes: %w", err))
-			log.Error(err)
+			log.ErrorLog.Print(err)
 			// Return early if we can't commit changes to avoid corrupted state
 			return i.combineErrors(errs)
 		}
@@ -386,7 +386,7 @@ func (i *Instance) Pause() error {
 	// Close tmux session first since it's using the git worktree
 	if err := i.tmuxSession.Close(); err != nil {
 		errs = append(errs, fmt.Errorf("failed to close tmux session: %w", err))
-		log.Error(err)
+		log.ErrorLog.Print(err)
 		// Return early if we can't close tmux to avoid corrupted state
 		return i.combineErrors(errs)
 	}
@@ -396,20 +396,20 @@ func (i *Instance) Pause() error {
 		// Remove worktree but keep branch
 		if err := i.gitWorktree.Remove(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to remove git worktree: %w", err))
-			log.Error(err)
+			log.ErrorLog.Print(err)
 			return i.combineErrors(errs)
 		}
 
 		// Only prune if remove was successful
 		if err := i.gitWorktree.Prune(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to prune git worktrees: %w", err))
-			log.Error(err)
+			log.ErrorLog.Print(err)
 			return i.combineErrors(errs)
 		}
 	}
 
 	if err := i.combineErrors(errs); err != nil {
-		log.Error(err)
+		log.ErrorLog.Print(err)
 		return err
 	}
 
@@ -429,7 +429,7 @@ func (i *Instance) Resume() error {
 
 	// Check if branch is checked out
 	if checked, err := i.gitWorktree.IsBranchCheckedOut(); err != nil {
-		log.Error(err)
+		log.ErrorLog.Print(err)
 		return fmt.Errorf("failed to check if branch is checked out: %w", err)
 	} else if checked {
 		return fmt.Errorf("cannot resume: branch is checked out, please switch to a different branch")
@@ -437,17 +437,17 @@ func (i *Instance) Resume() error {
 
 	// Setup git worktree
 	if err := i.gitWorktree.Setup(); err != nil {
-		log.Error(err)
+		log.ErrorLog.Print(err)
 		return fmt.Errorf("failed to setup git worktree: %w", err)
 	}
 
 	// Create new tmux session
 	if err := i.tmuxSession.Start(i.Program, i.gitWorktree.GetWorktreePath()); err != nil {
-		log.Error(err)
+		log.ErrorLog.Print(err)
 		// Cleanup git worktree if tmux session creation fails
 		if cleanupErr := i.gitWorktree.Cleanup(); cleanupErr != nil {
 			err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
-			log.Error(err)
+			log.ErrorLog.Print(err)
 		}
 		return fmt.Errorf("failed to start new session: %w", err)
 	}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -115,7 +115,7 @@ func (t *TmuxSession) Start(program string, workDir string) error {
 		time.Sleep(100 * time.Millisecond)
 		content, err := t.CapturePaneContent()
 		if err != nil {
-			log.Errorf("could not check 'do you trust the files screen': %v", err)
+			log.ErrorLog.Printf("could not check 'do you trust the files screen': %v", err)
 		}
 		if strings.Contains(content, "Do you trust") {
 			t.TapEnter()
@@ -158,7 +158,7 @@ func (m *statusMonitor) hash(s string) []byte {
 func (t *TmuxSession) TapEnter() {
 	_, err := t.ptmx.Write([]byte{0x0D})
 	if err != nil {
-		log.Errorf("could not send enter keystroke to PTY: %v", err)
+		log.ErrorLog.Printf("could not send enter keystroke to PTY: %v", err)
 	}
 }
 
@@ -167,7 +167,7 @@ func (t *TmuxSession) TapEnter() {
 func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool) {
 	content, err := t.CapturePaneContent()
 	if err != nil {
-		log.Errorf("error capturing pane content in status monitor: %v", err)
+		log.ErrorLog.Printf("error capturing pane content in status monitor: %v", err)
 		return false, false
 	}
 
@@ -231,7 +231,7 @@ func (t *TmuxSession) Attach() (chan struct{}, error) {
 			select {
 			case <-timeoutCh:
 			default:
-				log.Errorf("nuked first stdin: %s", buf[:nr])
+				log.ErrorLog.Printf("nuked first stdin: %s", buf[:nr])
 				continue
 			}
 
@@ -239,7 +239,7 @@ func (t *TmuxSession) Attach() (chan struct{}, error) {
 			if nr == 1 && buf[0] == 17 {
 				// Detach from the session
 				if err := t.Detach(); err != nil {
-					log.Errorf("Error detaching from tmux session: %v", err)
+					log.ErrorLog.Printf("Error detaching from tmux session: %v", err)
 				}
 				return
 			}

--- a/session/tmux/tmux_unix.go
+++ b/session/tmux/tmux_unix.go
@@ -23,10 +23,10 @@ func (t *TmuxSession) monitorWindowSize() {
 		// Use the current terminal height and width.
 		cols, rows, err := term.GetSize(int(os.Stdin.Fd()))
 		if err != nil {
-			log.Errorf("failed to update window size: %v", err)
+			log.ErrorLog.Printf("failed to update window size: %v", err)
 		} else {
 			if err := t.updateWindowSize(cols, rows); err != nil {
-				log.Errorf("failed to update window size: %v", err)
+				log.ErrorLog.Printf("failed to update window size: %v", err)
 			}
 		}
 	}

--- a/session/tmux/tmux_windows.go
+++ b/session/tmux/tmux_windows.go
@@ -16,10 +16,10 @@ func (t *TmuxSession) monitorWindowSize() {
 	doUpdate := func() {
 		cols, rows, err := term.GetSize(int(os.Stdin.Fd()))
 		if err != nil {
-			log.Errorf("failed to update window size: %v", err)
+			log.ErrorLog.Printf("failed to update window size: %v", err)
 		} else {
 			if err := t.updateWindowSize(cols, rows); err != nil {
-				log.Errorf("failed to update window size: %v", err)
+				log.ErrorLog.Printf("failed to update window size: %v", err)
 			}
 		}
 	}

--- a/ui/list.go
+++ b/ui/list.go
@@ -185,7 +185,7 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 	if i.Started() && hasMultipleRepos {
 		repoName, err := i.RepoName()
 		if err != nil {
-			log.Errorf("could not get repo name in instance renderer: %v", err)
+			log.ErrorLog.Printf("could not get repo name in instance renderer: %v", err)
 		} else {
 			branch += fmt.Sprintf(" (%s)", repoName)
 		}
@@ -265,7 +265,7 @@ func (l *List) Kill() {
 
 	// Kill the tmux session
 	if err := targetInstance.Kill(); err != nil {
-		log.Errorf("could not kill instance: %v", err)
+		log.ErrorLog.Printf("could not kill instance: %v", err)
 	}
 
 	// If you delete the last one in the list, select the previous one.
@@ -276,7 +276,7 @@ func (l *List) Kill() {
 	// Unregister the reponame.
 	repoName, err := targetInstance.RepoName()
 	if err != nil {
-		log.Errorf("could not get repo name: %v", err)
+		log.ErrorLog.Printf("could not get repo name: %v", err)
 	} else {
 		l.rmRepo(repoName)
 	}
@@ -309,7 +309,7 @@ func (l *List) addRepo(repo string) {
 
 func (l *List) rmRepo(repo string) {
 	if _, ok := l.repos[repo]; !ok {
-		log.Errorf("repo %s not found", repo)
+		log.ErrorLog.Printf("repo %s not found", repo)
 		return
 	}
 	l.repos[repo]--
@@ -327,7 +327,7 @@ func (l *List) AddInstance(instance *session.Instance) (finalize func()) {
 	return func() {
 		repoName, err := instance.RepoName()
 		if err != nil {
-			log.Errorf("could not get repo name: %v", err)
+			log.ErrorLog.Printf("could not get repo name: %v", err)
 			return
 		}
 


### PR DESCRIPTION
This adds a hidden --daemon flag which reads all the sessions from instances.json and taps yes on them. The daemon process is started by the main process upon exiting. The pid is written to the config directory. On the next startup, the daemon process is looked up and killed by the main process.

The --daemon flag always starts the daemon. It's up to the main process to check if the auto yes flag is enabled before starting the daemon. It always checks if a daemon is runnnig on startup, incase auto yes is disabled but was previously enabled.