### PR TITLE
chore(daemon, log): clean up error logging

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,15 +23,18 @@ func GetConfigDir() (string, error) {
 type Config struct {
 	// DefaultProgram is the default program to run in new instances
 	DefaultProgram string `json:"default_program"`
-	// AutoYes
+	// AutoYes is a flag to automatically accept all prompts.
 	AutoYes bool `json:"auto_yes"`
+	// DaemonPollInterval is the interval (ms) at which the daemon polls sessions for autoyes mode.
+	DaemonPollInterval int `json:"daemon_poll_interval"`
 }
 
 // DefaultConfig returns the default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		DefaultProgram: "claude",
-		AutoYes:        false,
+		DefaultProgram:     "claude",
+		AutoYes:            false,
+		DaemonPollInterval: 1000,
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -8,11 +8,13 @@ import (
 	"path/filepath"
 )
 
+const ConfigFileName = "config.json"
+
 // GetConfigDir returns the path to the application's configuration directory
 func GetConfigDir() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to get home directory: %w", err)
+		return "", fmt.Errorf("failed to get config home directory: %w", err)
 	}
 	return filepath.Join(homeDir, ".claude-squad"), nil
 }
@@ -33,37 +35,41 @@ func DefaultConfig() *Config {
 	}
 }
 
-// LoadConfig loads the configuration from disk
-func LoadConfig() (*Config, error) {
+// LoadConfig loads the configuration from disk. If it cannot be done, we return the default configuration.
+func LoadConfig() *Config {
 	configDir, err := GetConfigDir()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get config directory: %w", err)
+		log.ErrorLog.Printf("failed to get config directory: %v", err)
+		return DefaultConfig()
 	}
 
-	configPath := filepath.Join(configDir, "config.json")
+	configPath := filepath.Join(configDir, ConfigFileName)
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Create and save default config if file doesn't exist
 			defaultCfg := DefaultConfig()
-			if saveErr := SaveConfig(defaultCfg); saveErr != nil {
-				log.ErrorLog.Printf("Warning: failed to save default config: %v", saveErr)
+			if saveErr := saveConfig(defaultCfg); saveErr != nil {
+				log.WarningLog.Printf("failed to save default config: %v", saveErr)
 			}
-			return defaultCfg, nil
+			return defaultCfg
 		}
-		return DefaultConfig(), fmt.Errorf("failed to read config file: %w", err)
+
+		log.WarningLog.Printf("failed to get config file: %v", err)
+		return DefaultConfig()
 	}
 
 	var config Config
 	if err := json.Unmarshal(data, &config); err != nil {
-		return DefaultConfig(), fmt.Errorf("failed to parse config file: %w", err)
+		log.ErrorLog.Printf("failed to parse config file: %v", err)
+		return DefaultConfig()
 	}
 
-	return &config, nil
+	return &config
 }
 
-// SaveConfig saves the configuration to disk
-func SaveConfig(config *Config) error {
+// saveConfig saves the configuration to disk
+func saveConfig(config *Config) error {
 	configDir, err := GetConfigDir()
 	if err != nil {
 		return fmt.Errorf("failed to get config directory: %w", err)
@@ -73,7 +79,7 @@ func SaveConfig(config *Config) error {
 		return fmt.Errorf("failed to create config directory: %w", err)
 	}
 
-	configPath := filepath.Join(configDir, "config.json")
+	configPath := filepath.Join(configDir, ConfigFileName)
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)

--- a/log/log.go
+++ b/log/log.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 var (
@@ -45,4 +46,31 @@ func Close() {
 	_ = globalLogFile.Close()
 	// TODO: maybe only print if verbose flag is set?
 	fmt.Println("wrote logs to " + logFileName)
+}
+
+// Every is used to log at most once every timeout duration.
+type Every struct {
+	timeout time.Duration
+	timer   *time.Timer
+}
+
+func NewEvery(timeout time.Duration) *Every {
+	return &Every{timeout: timeout}
+}
+
+// ShouldLog returns true if the timeout has passed since the last log.
+func (e *Every) ShouldLog() bool {
+	if e.timer == nil {
+		e.timer = time.NewTimer(e.timeout)
+		e.timer.Reset(e.timeout)
+		return true
+	}
+
+	select {
+	case <-e.timer.C:
+		e.timer.Reset(e.timeout)
+		return true
+	default:
+		return false
+	}
 }

--- a/log/log.go
+++ b/log/log.go
@@ -32,7 +32,7 @@ func Initialize(daemon bool) {
 
 	fmtS := "%s"
 	if daemon {
-		fmtS = "%s [DAEMON]"
+		fmtS = "[DAEMON] %s"
 	}
 	InfoLog = log.New(f, fmt.Sprintf(fmtS, "INFO:"), log.Ldate|log.Ltime|log.Lshortfile)
 	WarningLog = log.New(f, fmt.Sprintf(fmtS, "WARNING:"), log.Ldate|log.Ltime|log.Lshortfile)

--- a/main.go
+++ b/main.go
@@ -31,7 +31,9 @@ var (
 			defer log.Close()
 
 			if daemonFlag {
-				err := daemon.RunDaemon()
+				cfg := config.LoadConfig()
+				err := daemon.RunDaemon(cfg)
+				log.ErrorLog.Printf("failed to start daemon %v", err)
 				return err
 			}
 
@@ -69,9 +71,9 @@ var (
 
 				// Kill any daemon that's running.
 				if err := daemon.StopDaemon(); err != nil {
-					log.ErrorLog.Printf("failed to stop daemon: %v", err)
+					return err
 				}
-				fmt.Println("Daemon has been stopped")
+				fmt.Println("daemon has been stopped")
 
 				return nil
 			}

--- a/main.go
+++ b/main.go
@@ -45,10 +45,7 @@ var (
 				return fmt.Errorf("error: claude-squad must be run from within a git repository")
 			}
 
-			cfg, err := config.LoadConfig()
-			if err != nil {
-				return fmt.Errorf("failed to load config: %w", err)
-			}
+			cfg := config.LoadConfig()
 
 			if resetFlag {
 				storage, err := session.NewStorage()
@@ -109,10 +106,7 @@ var (
 		Use:   "debug",
 		Short: "Print debug information like config paths",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.LoadConfig()
-			if err != nil {
-				return fmt.Errorf("failed to load config: %w", err)
-			}
+			cfg := config.LoadConfig()
 
 			configDir, err := config.GetConfigDir()
 			if err != nil {
@@ -120,7 +114,7 @@ var (
 			}
 			configJson, _ := json.MarshalIndent(cfg, "", "  ")
 
-			fmt.Printf("Config: %s\n%s\n", filepath.Join(configDir, "config.json"), configJson)
+			fmt.Printf("Config: %s\n%s\n", filepath.Join(configDir, config.ConfigFileName), configJson)
 
 			return nil
 		},


### PR DESCRIPTION
#### chore(config): return fewer errors in config.go
We can just fall back to the default config if there's issues reading the config from disk. We now log errors if there's any issues.

#### chore(daemon, log): clean up error logging
This change updates the daemon to have better error handling and logging. This change adds `log.Every` which lets us log every 60 seconds in case there's logging in hot loops. It also adds a config option to adjust the daemon poll interval.
