### PR TITLE
fix(tmux): ensure consistent state after detach error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,12 @@ require (
 	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/creack/pty v1.1.24
 	github.com/go-git/go-git/v5 v5.14.0
+	github.com/mattn/go-runewidth v0.0.16
+	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6
+	github.com/muesli/reflow v0.3.0
+	github.com/muesli/termenv v0.15.2
 	github.com/spf13/cobra v1.9.1
+	golang.org/x/sys v0.31.0
 	golang.org/x/term v0.30.0
 )
 
@@ -35,11 +40,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
-	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/muesli/termenv v0.15.2 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
@@ -49,7 +50,6 @@ require (
 	golang.org/x/crypto v0.35.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sync v0.11.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/session/tmux/tmux_unix.go
+++ b/session/tmux/tmux_unix.go
@@ -19,14 +19,20 @@ func (t *TmuxSession) monitorWindowSize() {
 	// Send initial SIGWINCH to trigger the first resize
 	_ = syscall.Kill(syscall.Getpid(), syscall.SIGWINCH)
 
+	everyN := log.NewEvery(60 * time.Second)
+
 	doUpdate := func() {
 		// Use the current terminal height and width.
 		cols, rows, err := term.GetSize(int(os.Stdin.Fd()))
 		if err != nil {
-			log.ErrorLog.Printf("failed to update window size: %v", err)
+			if everyN.ShouldLog() {
+				log.ErrorLog.Printf("failed to update window size: %v", err)
+			}
 		} else {
 			if err := t.updateWindowSize(cols, rows); err != nil {
-				log.ErrorLog.Printf("failed to update window size: %v", err)
+				if everyN.ShouldLog() {
+					log.ErrorLog.Printf("failed to update window size: %v", err)
+				}
 			}
 		}
 	}

--- a/ui/diff.go
+++ b/ui/diff.go
@@ -92,8 +92,6 @@ func (d *DiffPane) SetDiff(instance *session.Instance) {
 		d.diff = colorizeDiff(stats.Content)
 		d.viewport.SetContent(lipgloss.JoinVertical(lipgloss.Left, d.stats, d.diff))
 	}
-
-	return
 }
 
 func (d *DiffPane) String() string {


### PR DESCRIPTION
This change updates the tmux session to ensure a consistent state after detaching. On detach, we now assert that the ptmx is closed (or else panic) and that the stdin/stdout goroutines terminate. If detaching fails, the app exits and logs the error. This avoids the terminal pane from getting ruined by a bad detach.

Also, we don't need to save the old terminal state and restore the state because, on detaching, we immediately re-render the app. This removes some code which was doing nothing and reduces error checking.