### PR TITLE
feat(ui): add help screen

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -12,6 +12,7 @@ const (
 	KeyEnter
 	KeyNew
 	KeyKill
+	KeyHelp
 	KeyQuit
 	KeyReview
 	KeyPush
@@ -46,7 +47,8 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"tab":        KeyTab,
 	"c":          KeyCheckout,
 	"r":          KeyResume,
-	"s":          KeySubmit,
+	"p":          KeySubmit,
+	"h":          KeyHelp,
 }
 
 // GlobalkeyBindings is a global, immutable map of KeyName tot keybinding.
@@ -79,13 +81,17 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 		key.WithKeys("D"),
 		key.WithHelp("D", "kill"),
 	),
+	KeyHelp: key.NewBinding(
+		key.WithKeys("h"),
+		key.WithHelp("h", "help"),
+	),
 	KeyQuit: key.NewBinding(
 		key.WithKeys("q"),
 		key.WithHelp("q", "quit"),
 	),
 	KeySubmit: key.NewBinding(
-		key.WithKeys("s"),
-		key.WithHelp("s", "submit PR"),
+		key.WithKeys("p"),
+		key.WithHelp("p", "push branch"),
 	),
 	KeyPrompt: key.NewBinding(
 		key.WithKeys("N"),
@@ -97,7 +103,7 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 	),
 	KeyTab: key.NewBinding(
 		key.WithKeys("tab"),
-		key.WithHelp("tab", "switch tab"),
+		key.WithHelp("tab", "tab"),
 	),
 	KeyResume: key.NewBinding(
 		key.WithKeys("r"),

--- a/ui/err.go
+++ b/ui/err.go
@@ -1,8 +1,8 @@
 package ui
 
 import (
-	"claude-squad/log"
 	"github.com/charmbracelet/lipgloss"
+	"strings"
 )
 
 type ErrBox struct {
@@ -36,13 +36,10 @@ func (e *ErrBox) String() string {
 	var err string
 	if e.err != nil {
 		err = e.err.Error()
-		if len(err) > e.width {
-			if e.width-3 < len(err) {
-				log.ErrorLog.Print(err)
-				err = "error: ...(truncated)"
-			} else {
-				err = err[:e.width-3] + "..."
-			}
+		lines := strings.Split(err, "\n")
+		err = strings.Join(lines, "//")
+		if len(err) > e.width-3 && e.width-3 >= 0 {
+			err = err[:e.width-3] + "..."
 		}
 	}
 	return lipgloss.Place(e.width, e.height, lipgloss.Center, lipgloss.Center, errStyle.Render(err))

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -52,7 +52,7 @@ type Menu struct {
 	keyDown keys.KeyName
 }
 
-var defaultMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyPrompt, keys.KeyQuit}
+var defaultMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyPrompt, keys.KeyHelp, keys.KeyQuit}
 var newInstanceMenuOptions = []keys.KeyName{keys.KeySubmitName}
 var promptMenuOptions = []keys.KeyName{keys.KeyEnter}
 
@@ -128,7 +128,7 @@ func (m *Menu) addInstanceOptions() {
 	}
 
 	// System group
-	systemGroup := []keys.KeyName{keys.KeyTab, keys.KeyQuit}
+	systemGroup := []keys.KeyName{keys.KeyTab, keys.KeyHelp, keys.KeyQuit}
 
 	// Combine all groups
 	options = append(options, actionGroup...)
@@ -153,7 +153,7 @@ func (m *Menu) String() string {
 	}{
 		{0, 2}, // Instance management group (n, d)
 		{2, 5}, // Action group (enter, submit, pause/resume)
-		{5, 7}, // System group (tab, q)
+		{6, 8}, // System group (tab, help, q)
 	}
 
 	for i, k := range m.options {

--- a/ui/overlay/help.go
+++ b/ui/overlay/help.go
@@ -1,0 +1,48 @@
+package overlay
+
+import "github.com/charmbracelet/lipgloss"
+
+// TextInputOverlay represents a text input overlay with state management.
+type HelpOverlay struct {
+	width int
+}
+
+func (ho *HelpOverlay) SetSize(width int) {
+	ho.width = width
+}
+
+// Render renders the text input overlay.
+func (ho *HelpOverlay) Render() string {
+	// Create styles
+	style := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("62")).
+		Padding(1, 2)
+
+	titleStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("62")).
+		Bold(true).
+		MarginBottom(1)
+
+	subTitleStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("62")).
+		Underline(true).
+		MarginBottom(1)
+
+	// Build the view
+	content := titleStyle.Render("Help") + "\n"
+	content += subTitleStyle.Render("Context Switching")
+	content += `
+↵/o:     context switch into an instance 
+ctrl-q:  context switch out of an instance`
+	content += "\n\n"
+	content += subTitleStyle.Render("Checkout/Resume")
+	content += `
+c:       pauses an instance so the branch can be checked out
+r:       resumes an instance so it can continue working on its branch`
+	content += "\n\n"
+
+	content += lipgloss.Place(ho.width, 1, lipgloss.Center, lipgloss.Top, "(press 'ctrl+q' to close)")
+
+	return style.Render(content)
+}

--- a/ui/preview.go
+++ b/ui/preview.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"claude-squad/log"
 	"claude-squad/session"
 	"fmt"
 	"strings"
@@ -139,5 +140,7 @@ func (p *PreviewPane) String() string {
 	}
 
 	content := strings.Join(lines, "\n")
-	return previewPaneStyle.Width(p.width).Render(content)
+	rendered := previewPaneStyle.Width(p.width).Render(content)
+	log.InfoLog.Println(len(strings.Split(rendered, "\n")), p.width)
+	return rendered
 }


### PR DESCRIPTION
This change adds a help screen which can be opened by pressing 'h'.

It also renames the menu item "s - submit PR" to "p - push branch" to be more clear.

See https://github.com/smtg-ai/claude-squad/issues/29

<img width="1161" alt="image" src="https://github.com/user-attachments/assets/df462099-1ead-4a8f-bb1f-7bfcb12d65ce" />