### PR TITLE
feat(app, ui): Add help screen

### DIFF
--- a/app/help.go
+++ b/app/help.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	"claude-squad/session"
+	"claude-squad/ui"
+	"claude-squad/ui/overlay"
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type helpType int
+
+// Make a help state type enum
+const (
+	helpTypeGeneral helpType = iota
+	helpTypeInstanceStart
+	helpTypeInstanceAttach
+	helpTypeInstanceCheckout
+)
+
+var (
+	titleStyle  = lipgloss.NewStyle().Bold(true).Underline(true).Foreground(lipgloss.Color("#7D56F4"))
+	headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#36CFC9"))
+	keyStyle    = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#FFCC00"))
+	descStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFFFFF"))
+)
+
+func (h helpType) ToContent(instance *session.Instance) string {
+	switch h {
+	case helpTypeGeneral:
+		content := lipgloss.JoinVertical(lipgloss.Left,
+			titleStyle.Render("Claude Squad"),
+			"",
+			"A terminal UI that manages multiple Claude Code (and other local agents) in separate workspaces.",
+			"",
+			headerStyle.Render("Managing:"),
+			keyStyle.Render("n")+descStyle.Render("     - Create a new session"),
+			keyStyle.Render("N")+descStyle.Render("     - Create a new session with a prompt"),
+			keyStyle.Render("D")+descStyle.Render("     - Kill (delete) the selected session"),
+			keyStyle.Render("↑/j, ↓/k")+descStyle.Render(" - Navigate between sessions"),
+			keyStyle.Render("↵/o")+descStyle.Render("   - Attach to the selected session"),
+			keyStyle.Render("ctrl-q")+descStyle.Render(" - Detach from session"),
+			"",
+			headerStyle.Render("Other:"),
+			keyStyle.Render("tab")+descStyle.Render("   - Switch between preview and diff tabs"),
+			keyStyle.Render("shift-↓/↑")+descStyle.Render(" - Scroll in diff view"),
+			keyStyle.Render("q")+descStyle.Render("     - Quit the application"),
+			"",
+			headerStyle.Render("Handoff:"),
+			keyStyle.Render("p")+descStyle.Render("     - Commit and push branch to github"),
+			keyStyle.Render("c")+descStyle.Render("     - Checkout: commit changes and pause session"),
+			keyStyle.Render("r")+descStyle.Render("     - Resume a paused session"),
+		)
+		return content
+
+	case helpTypeInstanceStart:
+		content := lipgloss.JoinVertical(lipgloss.Left,
+			titleStyle.Render("Instance Created"),
+			"",
+			descStyle.Render("New session created:"),
+			descStyle.Render(fmt.Sprintf("• Git branch: %s (isolated worktree)", lipgloss.NewStyle().Bold(true).Render(instance.Branch))),
+			descStyle.Render(fmt.Sprintf("• %s running in background tmux session", lipgloss.NewStyle().Bold(true).Render(instance.Program))),
+			"",
+			headerStyle.Render("Managing:"),
+			keyStyle.Render("↵/o")+descStyle.Render("   - Attach to the session to interact with it directly"),
+			keyStyle.Render("tab")+descStyle.Render("   - Switch preview panes to view session diff"),
+			keyStyle.Render("D")+descStyle.Render("     - Kill (delete) the selected session"),
+			"",
+			headerStyle.Render("Handoff:"),
+			keyStyle.Render("c")+descStyle.Render("     - Checkout this instance's branch"),
+			keyStyle.Render("p")+descStyle.Render("     - Push branch to GitHub to create a PR"),
+		)
+		return content
+
+	case helpTypeInstanceAttach:
+		content := lipgloss.JoinVertical(lipgloss.Left,
+			titleStyle.Render("Attaching to Instance"),
+			"",
+			descStyle.Render("To detach from a session, press ")+keyStyle.Render("ctrl-q"),
+		)
+		return content
+
+	case helpTypeInstanceCheckout:
+		content := lipgloss.JoinVertical(lipgloss.Left,
+			titleStyle.Render("Checkout Instance"),
+			"",
+			"Changes will be committed and pushed to GitHub. The branch name has been copied to your clipboard for you to checkout.",
+			"",
+			"Feel free to make changes to the branch and commit them. When resuming, the session will continue from where you left off.",
+			"",
+			headerStyle.Render("Commands:"),
+			keyStyle.Render("c")+descStyle.Render(" - Checkout: commit changes and pause session"),
+			keyStyle.Render("r")+descStyle.Render(" - Resume a paused session"),
+		)
+		return content
+	}
+	return ""
+}
+
+// showHelpScreen displays the help screen overlay
+func (m *home) showHelpScreen(helpType helpType, onDismiss func()) (tea.Model, tea.Cmd) {
+	content := helpType.ToContent(m.list.GetSelectedInstance())
+
+	m.textOverlay = overlay.NewTextOverlay(content)
+	m.textOverlay.OnDismiss = onDismiss
+	m.state = stateHelp
+	return m, nil
+}
+
+// handleHelpState handles key events when in help state
+func (m *home) handleHelpState(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Any key press will close the help overlay
+	shouldClose := m.textOverlay.HandleKeyPress(msg)
+	if shouldClose {
+		m.state = stateDefault
+		return m, tea.Sequence(
+			tea.WindowSize(),
+			func() tea.Msg {
+				m.menu.SetState(ui.StateDefault)
+				return nil
+			},
+		)
+	}
+
+	return m, nil
+}

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -12,7 +12,6 @@ const (
 	KeyEnter
 	KeyNew
 	KeyKill
-	KeyHelp
 	KeyQuit
 	KeyReview
 	KeyPush
@@ -24,6 +23,7 @@ const (
 	KeyCheckout
 	KeyResume
 	KeyPrompt // New key for entering a prompt
+	KeyHelp   // Key for showing help screen
 
 	// Diff keybindings
 	KeyShiftUp
@@ -48,7 +48,7 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"c":          KeyCheckout,
 	"r":          KeyResume,
 	"p":          KeySubmit,
-	"h":          KeyHelp,
+	"?":          KeyHelp,
 }
 
 // GlobalkeyBindings is a global, immutable map of KeyName tot keybinding.
@@ -82,8 +82,8 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 		key.WithHelp("D", "kill"),
 	),
 	KeyHelp: key.NewBinding(
-		key.WithKeys("h"),
-		key.WithHelp("h", "help"),
+		key.WithKeys("?"),
+		key.WithHelp("?", "help"),
 	),
 	KeyQuit: key.NewBinding(
 		key.WithKeys("q"),

--- a/ui/overlay/textOverlay.go
+++ b/ui/overlay/textOverlay.go
@@ -1,0 +1,55 @@
+package overlay
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TextOverlay represents a text screen overlay
+type TextOverlay struct {
+	// Whether the overlay has been dismissed
+	Dismissed bool
+	// Callback function to be called when the overlay is dismissed
+	OnDismiss func()
+	// Content to display in the overlay
+	content string
+
+	width int
+}
+
+// NewTextOverlay creates a new text screen overlay with the given title and content
+func NewTextOverlay(content string) *TextOverlay {
+	return &TextOverlay{
+		Dismissed: false,
+		content:   content,
+	}
+}
+
+// HandleKeyPress processes a key press and updates the state
+// Returns true if the overlay should be closed
+func (t *TextOverlay) HandleKeyPress(msg tea.KeyMsg) bool {
+	// Close on any key
+	t.Dismissed = true
+	// Call the OnDismiss callback if it exists
+	if t.OnDismiss != nil {
+		t.OnDismiss()
+	}
+	return true
+}
+
+// Render renders the text overlay
+func (t *TextOverlay) Render(opts ...WhitespaceOption) string {
+	// Create styles
+	style := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("62")).
+		Padding(1, 2).
+		Width(t.width)
+
+	// Apply the border style and return
+	return style.Render(t.content)
+}
+
+func (t *TextOverlay) SetWidth(width int) {
+	t.width = width
+}


### PR DESCRIPTION
Towards #29 

This change adds a new `textOverlay` component which is used to render various help screens in the app.

https://github.com/user-attachments/assets/c5fc2977-5ff1-48b6-9cf9-478a6f05dbed