### PR TITLE
feat(app/help): Only show just-in-time help screens once

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"claude-squad/config"
 	"claude-squad/keys"
 	"claude-squad/log"
 	"claude-squad/session"
@@ -55,8 +56,12 @@ type home struct {
 	// global spinner instance. we plumb this down to where it's needed
 	spinner spinner.Model
 
-	// storage
+	// storage is the interface for saving/loading data to/from the app's state
 	storage *session.Storage
+	// appConfig stores persistent application configuration
+	appConfig *config.Config
+	// appState stores persistent application state like seen help screens
+	appState config.AppState
 
 	// state
 	state state
@@ -78,8 +83,14 @@ type home struct {
 }
 
 func newHome(ctx context.Context, program string, autoYes bool) *home {
+	// Load application config
+	appConfig := config.LoadConfig()
+
+	// Load application state
+	appState := config.LoadState()
+
 	// Initialize storage
-	storage, err := session.NewStorage()
+	storage, err := session.NewStorage(appState)
 	if err != nil {
 		fmt.Printf("Failed to initialize storage: %v\n", err)
 		os.Exit(1)
@@ -92,9 +103,11 @@ func newHome(ctx context.Context, program string, autoYes bool) *home {
 		tabbedWindow: ui.NewTabbedWindow(ui.NewPreviewPane(), ui.NewDiffPane()),
 		errBox:       ui.NewErrBox(),
 		storage:      storage,
+		appConfig:    appConfig,
 		program:      program,
 		autoYes:      autoYes,
 		state:        stateDefault,
+		appState:     appState,
 	}
 	h.list = ui.NewList(&h.spinner, autoYes)
 

--- a/config/config.go
+++ b/config/config.go
@@ -90,3 +90,8 @@ func saveConfig(config *Config) error {
 
 	return os.WriteFile(configPath, data, 0644)
 }
+
+// SaveConfig exports the saveConfig function for use by other packages
+func SaveConfig(config *Config) error {
+	return saveConfig(config)
+}

--- a/config/state.go
+++ b/config/state.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"claude-squad/log"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	StateFileName     = "state.json"
+	InstancesFileName = "instances.json"
+)
+
+// InstanceStorage handles instance-related operations
+type InstanceStorage interface {
+	// SaveInstances saves the raw instance data
+	SaveInstances(instancesJSON json.RawMessage) error
+	// GetInstances returns the raw instance data
+	GetInstances() json.RawMessage
+	// DeleteAllInstances removes all stored instances
+	DeleteAllInstances() error
+}
+
+// AppState handles application-level state
+type AppState interface {
+	// GetHelpScreensSeen returns the bitmask of seen help screens
+	GetHelpScreensSeen() uint32
+	// SetHelpScreensSeen updates the bitmask of seen help screens
+	SetHelpScreensSeen(seen uint32) error
+}
+
+// StateManager combines instance storage and app state management
+type StateManager interface {
+	InstanceStorage
+	AppState
+}
+
+// State represents the application state that persists between sessions
+type State struct {
+	// HelpScreensSeen is a bitmask tracking which help screens have been shown
+	HelpScreensSeen uint32 `json:"help_screens_seen"`
+	// Instances stores the serialized instance data as raw JSON
+	InstancesData json.RawMessage `json:"instances"`
+}
+
+// DefaultState returns the default state
+func DefaultState() *State {
+	return &State{
+		HelpScreensSeen: 0,
+		InstancesData:   json.RawMessage("[]"),
+	}
+}
+
+// LoadState loads the state from disk. If it cannot be done, we return the default state.
+func LoadState() *State {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		log.ErrorLog.Printf("failed to get config directory: %v", err)
+		return DefaultState()
+	}
+
+	statePath := filepath.Join(configDir, StateFileName)
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Create and save default state if file doesn't exist
+			defaultState := DefaultState()
+			if saveErr := SaveState(defaultState); saveErr != nil {
+				log.WarningLog.Printf("failed to save default state: %v", saveErr)
+			}
+			return defaultState
+		}
+
+		log.WarningLog.Printf("failed to get state file: %v", err)
+		return DefaultState()
+	}
+
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		log.ErrorLog.Printf("failed to parse state file: %v", err)
+		return DefaultState()
+	}
+
+	return &state
+}
+
+// SaveState saves the state to disk
+func SaveState(state *State) error {
+	configDir, err := GetConfigDir()
+	if err != nil {
+		return fmt.Errorf("failed to get config directory: %w", err)
+	}
+
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	statePath := filepath.Join(configDir, StateFileName)
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	return os.WriteFile(statePath, data, 0644)
+}
+
+// InstanceStorage interface implementation
+
+// SaveInstances saves the raw instance data
+func (s *State) SaveInstances(instancesJSON json.RawMessage) error {
+	s.InstancesData = instancesJSON
+	return SaveState(s)
+}
+
+// GetInstances returns the raw instance data
+func (s *State) GetInstances() json.RawMessage {
+	return s.InstancesData
+}
+
+// DeleteAllInstances removes all stored instances
+func (s *State) DeleteAllInstances() error {
+	s.InstancesData = json.RawMessage("[]")
+	return SaveState(s)
+}
+
+// AppState interface implementation
+
+// GetHelpScreensSeen returns the bitmask of seen help screens
+func (s *State) GetHelpScreensSeen() uint32 {
+	return s.HelpScreensSeen
+}
+
+// SetHelpScreensSeen updates the bitmask of seen help screens
+func (s *State) SetHelpScreensSeen(seen uint32) error {
+	s.HelpScreensSeen = seen
+	return SaveState(s)
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -18,7 +18,8 @@ import (
 // It's expected that the main process kills the daemon when the main process starts.
 func RunDaemon(cfg *config.Config) error {
 	log.InfoLog.Printf("starting daemon")
-	storage, err := session.NewStorage()
+	state := config.LoadState()
+	storage, err := session.NewStorage(state)
 	if err != nil {
 		return fmt.Errorf("failed to initialize storage: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -48,9 +48,10 @@ var (
 			}
 
 			cfg := config.LoadConfig()
+			state := config.LoadState()
 
 			if resetFlag {
-				storage, err := session.NewStorage()
+				storage, err := session.NewStorage(state)
 				if err != nil {
 					return fmt.Errorf("failed to initialize storage: %w", err)
 				}


### PR DESCRIPTION
Follow up to #36, closes #29 

This change adds a field to the stored state, using a bitmask to represent which help screens have been shown thus far. This value persists between app invocations. We also move `instances.json` to a common `state.json` that can be extended further in the future.

https://github.com/user-attachments/assets/1f4bebf3-4e80-453c-818b-af0a6d8cb15c