### PR TITLE
fix(app): fix attaching bugs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -243,25 +243,45 @@ func (m *home) handleQuit() (tea.Model, tea.Cmd) {
 	return m, tea.Quit
 }
 
-func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
+func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly bool) {
 	// Handle menu highlighting when you press a button. We intercept it here and immediately return to
 	// update the ui while re-sending the keypress. Then, on the next call to this, we actually handle the keypress.
-	if !m.keySent && m.state != statePrompt && m.state != stateHelp {
-		// If it's in the global keymap, we should try to highlight it.
-		name, ok := keys.GlobalKeyStringsMap[msg.String()]
-		// Skip the menu highlighting if the key is not in the map or we are using the shift up and down keys.
-		if ok && name != keys.KeyShiftDown && name != keys.KeyShiftUp {
-			m.keySent = true
-			// TODO: cleanup: when you press enter on stateNew, we use keys.KeySubmitName. We should unify the keymap.
-			if name == keys.KeyEnter && m.state == stateNew {
-				name = keys.KeySubmitName
-			}
-			return m, tea.Batch(
-				func() tea.Msg { return msg },
-				m.keydownCallback(name))
-		}
+	if m.keySent {
+		m.keySent = false
+		return nil, false
 	}
-	m.keySent = false
+	if m.state == statePrompt || m.state == stateHelp {
+		return nil, false
+	}
+	// If it's in the global keymap, we should try to highlight it.
+	name, ok := keys.GlobalKeyStringsMap[msg.String()]
+	if !ok {
+		return nil, false
+	}
+
+	if m.list.GetSelectedInstance() != nil && m.list.GetSelectedInstance().Paused() && name == keys.KeyEnter {
+		return nil, false
+	}
+	if name == keys.KeyShiftDown || name == keys.KeyShiftUp {
+		return nil, false
+	}
+
+	// Skip the menu highlighting if the key is not in the map or we are using the shift up and down keys.
+	// TODO: cleanup: when you press enter on stateNew, we use keys.KeySubmitName. We should unify the keymap.
+	if name == keys.KeyEnter && m.state == stateNew {
+		name = keys.KeySubmitName
+	}
+	m.keySent = true
+	return tea.Batch(
+		func() tea.Msg { return msg },
+		m.keydownCallback(name)), true
+}
+
+func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
+	cmd, returnEarly := m.handleMenuHighlighting(msg)
+	if returnEarly {
+		return m, cmd
+	}
 
 	if m.state == stateHelp {
 		return m.handleHelpState(msg)
@@ -507,6 +527,10 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		return m, tea.WindowSize()
 	case keys.KeyEnter:
 		if m.list.NumInstances() == 0 {
+			return m, nil
+		}
+		selected := m.list.GetSelectedInstance()
+		if selected == nil || selected.Paused() || !selected.TmuxAlive() {
 			return m, nil
 		}
 		// Show help screen before attaching

--- a/session/instance.go
+++ b/session/instance.go
@@ -360,6 +360,11 @@ func (i *Instance) Paused() bool {
 	return i.Status == Paused
 }
 
+// TmuxAlive returns true if the tmux session is alive. This is a sanity check before attaching.
+func (i *Instance) TmuxAlive() bool {
+	return i.tmuxSession.DoesSessionExist()
+}
+
 // Pause stops the tmux session and removes the worktree, preserving the branch
 func (i *Instance) Pause() error {
 	if !i.started {

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -374,6 +374,10 @@ func DoesSessionExist(name string) bool {
 	return existsCmd.Run() == nil
 }
 
+func (t *TmuxSession) DoesSessionExist() bool {
+	return DoesSessionExist(t.sanitizedName)
+}
+
 // CapturePaneContent captures the content of the tmux pane
 func (t *TmuxSession) CapturePaneContent() (string, error) {
 	// Add -e flag to preserve escape sequences (ANSI color codes)


### PR DESCRIPTION
Previously, attaching to a paused instance or an instance which has a broken tmux session would destroy the terminal pane. Now, we check for these two cases.

Also, this change refactors some of the menu highlighting since it was getting complicated.