### PR TITLE
fix(app): use shift tab for auto yes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -122,9 +122,6 @@ func newHome(ctx context.Context, program string, autoYes bool) *home {
 	for _, instance := range instances {
 		// Call the finalizer immediately.
 		h.list.AddInstance(instance)()
-		if autoYes {
-			instance.AutoYes = true
-		}
 	}
 
 	return h
@@ -427,6 +424,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 			Title:   "",
 			Path:    ".",
 			Program: m.program,
+			AutoYes: m.autoYes,
 		})
 		if err != nil {
 			return m, m.handleError(err)
@@ -448,6 +446,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 			Title:   "",
 			Path:    ".",
 			Program: m.program,
+			AutoYes: m.autoYes,
 		})
 		if err != nil {
 			return m, m.handleError(err)

--- a/session/instance.go
+++ b/session/instance.go
@@ -130,7 +130,7 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 
 	if instance.Paused() {
 		instance.started = true
-		instance.tmuxSession = tmux.NewTmuxSession(instance.Title, instance.Program)
+		instance.tmuxSession = tmux.NewTmuxSession(instance.Title, instance.Program, instance.AutoYes)
 	} else {
 		if err := instance.Start(false); err != nil {
 			return nil, err
@@ -170,7 +170,7 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 		Width:     0,
 		CreatedAt: t,
 		UpdatedAt: t,
-		AutoYes:   false,
+		AutoYes:   opts.AutoYes,
 	}, nil
 }
 
@@ -191,7 +191,7 @@ func (i *Instance) Start(firstTimeSetup bool) error {
 		return fmt.Errorf("instance title cannot be empty")
 	}
 
-	tmuxSession := tmux.NewTmuxSession(i.Title, i.Program)
+	tmuxSession := tmux.NewTmuxSession(i.Title, i.Program, i.AutoYes)
 	i.tmuxSession = tmuxSession
 
 	if firstTimeSetup {


### PR DESCRIPTION
Claude code recently added the option to auto accept edits if you hit shift+tab at the beginning of a session. This change updates auto yes mode to press shift tab when a new session is made. It doesn't auto accept bash command execution, so we still check the stdout for prompts and tap enter as needed.

In https://github.com/smtg-ai/claude-squad/issues/39, we don't handle the case where the "Yes, and don't ask again" option is gone. This change updates the search text to search for "No, and tell claude what to do differently".

Closes: https://github.com/smtg-ai/claude-squad/issues/39