### PR TITLE
fix(app): ensure autoyes mode still works

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -112,7 +112,7 @@ func newHome(ctx context.Context, program string, autoYes bool) *home {
 	h.list = ui.NewList(&h.spinner, autoYes)
 
 	// Load saved instances
-	instances, err := storage.LoadInstances()
+	instances, err := storage.LoadAndStartInstances(autoYes)
 	if err != nil {
 		fmt.Printf("Failed to load instances: %v\n", err)
 		os.Exit(1)
@@ -307,7 +307,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 				return m, m.handleError(fmt.Errorf("title cannot be empty"))
 			}
 
-			if err := instance.Start(true); err != nil {
+			if err := instance.Start(true, m.autoYes); err != nil {
 				m.list.Kill()
 				m.state = stateDefault
 				return m, m.handleError(err)
@@ -317,11 +317,6 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 				return m, m.handleError(err)
 			}
 			// Instance added successfully, call the finalizer.
-			m.newInstanceFinalizer()
-			if m.autoYes {
-				instance.AutoYes = true
-			}
-
 			m.newInstanceFinalizer()
 			m.state = stateDefault
 			if m.promptAfterName {
@@ -542,7 +537,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		if selected == nil {
 			return m, nil
 		}
-		if err := selected.Resume(); err != nil {
+		if err := selected.Resume(m.autoYes); err != nil {
 			return m, m.handleError(err)
 		}
 		return m, tea.WindowSize()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -24,13 +24,10 @@ func RunDaemon(cfg *config.Config) error {
 		return fmt.Errorf("failed to initialize storage: %w", err)
 	}
 
-	instances, err := storage.LoadInstances()
+	// Assume autoyes is on.
+	instances, err := storage.LoadAndStartInstances(true)
 	if err != nil {
 		return fmt.Errorf("failed to load instacnes: %w", err)
-	}
-	for _, instance := range instances {
-		// Assume AutoYes is true if the daemon is running.
-		instance.AutoYes = true
 	}
 
 	pollInterval := time.Duration(cfg.DaemonPollInterval) * time.Millisecond


### PR DESCRIPTION
https://github.com/smtg-ai/claude-squad/pull/40 broke auto yes mode. We would not press yes on prompts when we should have been.

This PR refactors things a bit so that we do press yes to prompts. For shift+tab in claude, we only make a best efford attempt to press this for the user when making new tmux sessions (happens on resume and instance creation). Otherwise, it's up to the user to press it. They have the option to not press shift+tab and let claude squad handle autoyes mode. The daemon still works as well.