### PR TITLE
FIX: go.mod to allow `go install github.com/smtg-ai/claude-squad@late…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module claude-squad
+module github.com/smtg-ai/claude-squad
 
 go 1.23.0
 


### PR DESCRIPTION
…st` (according to claude)

Claude Code hopes this will fix problem below when one wants to install/compile from sources directly by providing repository URL:

```
$ go install github.com/smtg-ai/claude-squad@latest
go: github.com/smtg-ai/claude-squad@latest: version constraints conflict:
        github.com/smtg-ai/claude-squad@v1.0.3: parsing go.mod:
        module declares its path as: claude-squad
                but was required as: github.com/smtg-ai/claude-squad
```

https://github.com/smtg-ai/claude-squad/issues/93