### PR TITLE
Fix "Failed to start new session" for users with a fetch installed

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -77,9 +77,9 @@ func GetClaudeCommand() (string, error) {
 	// For zsh, source .zshrc; for bash, source .bashrc
 	var shellCmd string
 	if strings.Contains(shell, "zsh") {
-		shellCmd = "source ~/.zshrc 2>/dev/null || true; which claude"
+		shellCmd = "source ~/.zshrc &>/dev/null || true; which claude"
 	} else if strings.Contains(shell, "bash") {
-		shellCmd = "source ~/.bashrc 2>/dev/null || true; which claude"
+		shellCmd = "source ~/.bashrc &>/dev/null || true; which claude"
 	} else {
 		shellCmd = "which claude"
 	}


### PR DESCRIPTION
The way that the `default_program` used for execution is found and set to the config, was by sourcing `.bashrc` or `.zshrc` then running `which claude`. Only redirecting `stderr` to `/dev/null` like this.

```
shellCmd = "source ~/.zshrc 2>/dev/null || true; which claude"
shellCmd = "source ~/.bashrc 2>/dev/null || true; which claude"
 ```

For users that have a [fetch script](https://github.com/fastfetch-cli/fastfetch) installed, or any configuration where something is written to `stdout` during initialisation the whole output would be set as the `default_program`, causing the "Failed to start new session ..." error for new users.
```json
{
  "default_program": "\u001b[36m                         \u001b[33maa0\u001b[31m@\u001b[32maa7\u001b[0m ~\u001b[0m\n    \u001b[36m       /\\                \u001b[36m󰣇  \u001b[34mSystem\u001b[0m        Arch Linux\n    \u001b[36m      /  \\               \u001b[36m  \u001b[34mKernel\u001b[0m        Linux 6.14.9-zen1-1-zen (x86_64)\n    \u001b[36m     /\\   \\              \u001b[36m  \u001b[34mShell\u001b[0m         zsh\n    \u001b[36m    /      \\             \u001b[36m  \u001b[34mUptime\u001b[0m        1 day, 8 hours, 26 minutes\n    \u001b[36m   /   ,,   \\            \u001b[36m  \u001b[34mDesktop\u001b[0m       Hyprland (Wayland)\n    \u001b[36m  /   |  |  -\\           \u001b[36m  \u001b[34mMemory\u001b[0m        5.26 GiB / 7.52 GiB (\u001b[36m70%\u001b[0m)\n    \u001b[36m /_-''    ''-_\\          \u001b[36m󱥎  \u001b[34mStorage (/)\u001b[0m   150.73 GiB / 217.29 GiB (\u001b[36m69%\u001b[0m)\n    \u001b[36m                         \u001b[36m  \u001b[34mColors\u001b[0m        \u001b[34m  \u001b[36m  \u001b[32m  \u001b[33m  \u001b[31m  \u001b[35m  \u001b[0m\n/usr/bin/claude",
  "auto_yes": false,
  "daemon_poll_interval": 1000,
  "branch_prefix": "aa0/"
}
```

The fix redirects both `stdout` and `stderr` to `/dev/null` to stop this from happening.

I believe this should fix #132 #96 and #115.