### PR TITLE
feat: add support for --dangerously-skip-permissions in claude

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -20,9 +20,9 @@ import (
 const GlobalInstanceLimit = 10
 
 // Run is the main entrypoint into the application.
-func Run(ctx context.Context, program string, autoYes bool) error {
+func Run(ctx context.Context, program string, autoYes bool, danger bool) error {
 	p := tea.NewProgram(
-		newHome(ctx, program, autoYes),
+		newHome(ctx, program, autoYes, danger),
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(), // Mouse scroll
 	)
@@ -51,6 +51,7 @@ type home struct {
 
 	program string
 	autoYes bool
+	danger  bool
 
 	// storage is the interface for saving/loading data to/from the app's state
 	storage *session.Storage
@@ -93,7 +94,7 @@ type home struct {
 	confirmationOverlay *overlay.ConfirmationOverlay
 }
 
-func newHome(ctx context.Context, program string, autoYes bool) *home {
+func newHome(ctx context.Context, program string, autoYes bool, danger bool) *home {
 	// Load application config
 	appConfig := config.LoadConfig()
 
@@ -117,6 +118,7 @@ func newHome(ctx context.Context, program string, autoYes bool) *home {
 		appConfig:    appConfig,
 		program:      program,
 		autoYes:      autoYes,
+		danger:       danger,
 		state:        stateDefault,
 		appState:     appState,
 	}
@@ -135,6 +137,9 @@ func newHome(ctx context.Context, program string, autoYes bool) *home {
 		h.list.AddInstance(instance)()
 		if autoYes {
 			instance.AutoYes = true
+		}
+		if danger {
+			instance.Danger = true
 		}
 	}
 
@@ -456,6 +461,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 			Title:   "",
 			Path:    ".",
 			Program: m.program,
+			Danger:  m.danger,
 		})
 		if err != nil {
 			return m, m.handleError(err)
@@ -477,6 +483,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 			Title:   "",
 			Path:    ".",
 			Program: m.program,
+			Danger:  m.danger,
 		})
 		if err != nil {
 			return m, m.handleError(err)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -238,6 +238,7 @@ func TestConfirmationFlowSimulation(t *testing.T) {
 		Path:    t.TempDir(),
 		Program: "claude",
 		AutoYes: false,
+		Danger:  false,
 	})
 	require.NoError(t, err)
 	_ = list.AddInstance(instance)

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,8 @@ type Config struct {
 	DaemonPollInterval int `json:"daemon_poll_interval"`
 	// BranchPrefix is the prefix used for git branches created by the application.
 	BranchPrefix string `json:"branch_prefix"`
+	// Danger is a flag to run claude with --dangerously-skip-permissions
+	Danger bool `json:"danger"`
 }
 
 // DefaultConfig returns the default configuration

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	programFlag string
 	autoYesFlag bool
 	daemonFlag  bool
+	dangerFlag  bool
 	rootCmd     = &cobra.Command{
 		Use:   "claude-squad",
 		Short: "Claude Squad - Manage multiple AI agents like Claude Code, Aider, Codex, and Amp.",
@@ -59,6 +60,11 @@ var (
 			if autoYesFlag {
 				autoYes = true
 			}
+			// Danger flag overrides config
+			danger := cfg.Danger
+			if dangerFlag {
+				danger = true
+			}
 			if autoYes {
 				defer func() {
 					if err := daemon.LaunchDaemon(); err != nil {
@@ -71,7 +77,7 @@ var (
 				log.ErrorLog.Printf("failed to stop daemon: %v", err)
 			}
 
-			return app.Run(ctx, program, autoYes)
+			return app.Run(ctx, program, autoYes, danger)
 		},
 	}
 
@@ -147,6 +153,8 @@ func init() {
 		"[experimental] If enabled, all instances will automatically accept prompts")
 	rootCmd.Flags().BoolVar(&daemonFlag, "daemon", false, "Run a program that loads all sessions"+
 		" and runs autoyes mode on them.")
+	rootCmd.Flags().BoolVar(&dangerFlag, "danger", false,
+		"Run claude with --dangerously-skip-permissions flag")
 
 	// Hide the daemonFlag as it's only for internal use
 	err := rootCmd.Flags().MarkHidden("daemon")

--- a/session/storage.go
+++ b/session/storage.go
@@ -18,6 +18,7 @@ type InstanceData struct {
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 	AutoYes   bool      `json:"auto_yes"`
+	Danger    bool      `json:"danger"`
 
 	Program   string          `json:"program"`
 	Worktree  GitWorktreeData `json:"worktree"`


### PR DESCRIPTION
## Summary

This PR adds support for the `--danger` flag in claude-squad, which automatically appends
`--dangerously-skip-permissions` to claude commands when creating new instances.

## Changes

- Added a new `--danger` CLI flag that can be used when starting claude-squad
- Added `Danger` field to config, instance, and storage structures to persist the setting
- Modified instance startup logic to append `--dangerously-skip-permissions` to claude commands when danger mode is enabled
- The flag only affects claude instances (not aider or other programs)

## Usage

```bash
# Start claude-squad with danger mode enabled
cs --danger