### PR TITLE
fix: Fix nil pointer dereference panic in debug command

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,6 +116,9 @@ var (
 		Use:   "debug",
 		Short: "Print debug information like config paths",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Initialize(false)
+			defer log.Close()
+
 			cfg := config.LoadConfig()
 
 			configDir, err := config.GetConfigDir()


### PR DESCRIPTION
  ## Problem
  Running `go run main.go debug` causes a nil pointer dereference panic:

  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102bc7b60]

  goroutine 1 [running]:
  log.(*Logger).output(...)
          /path/to/go/src/log/log.go:203 +0x30
  log.(*Logger).Printf(...)
          /path/to/go/src/log/log.go:268 +0x5c
  claude-squad/config.LoadConfig()
          /path/to/claude-squad/config/config.go:139 +0x240

  ## Root Cause
  - The `debug` command calls `config.LoadConfig()`
  - `LoadConfig()` tries to use `log.ErrorLog.Printf()`
  - However, `log.ErrorLog` is nil because `log.Initialize()` hasn't been called yet

  ## Solution
  - Add `log.Initialize(false)` at the beginning of `debugCmd`'s `RunE` function
  - Add `defer log.Close()` to ensure proper resource cleanup

  ## Testing
  - Verified `go run main.go debug` works correctly
  - Verified built binary also works correctly