### PR TITLE
fix: config creation when remote is empty

### DIFF
--- a/session/git/worktree_branch.go
+++ b/session/git/worktree_branch.go
@@ -3,6 +3,7 @@ package git
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -37,7 +38,10 @@ func (g *GitWorktree) cleanupExistingBranch(repo *git.Repository) error {
 	cfg.Raw.RemoveSection(worktreeSection)
 
 	if err := repo.Storer.SetConfig(cfg); err != nil {
-		return fmt.Errorf("failed to update repository config after removing branch %s: %w", g.branchName, err)
+		// If the error contains "empty URL" we can continue without updating as the branch ref has already been removed
+		if !strings.Contains(err.Error(), "empty URL") {
+			return fmt.Errorf("failed to update repository config after removing branch %s: %w", g.branchName, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The scenario this PR fixes:

When trying to create a new session (for the first time) Claude Squad errors with:

```
$ cd ~/git/sammcj/mcp-devtools
$ cs

# (Press 'n' to start a new session, entered 'devtools' as the name)

failed to setup git worktree: failed to cleanup existing branch: failed to update repository config after removing branch samm/devtools: remote config: empty URL
```
