### PR TITLE
Add per-instance program selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,156 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Claude Squad is a terminal multiplexer for AI coding assistants written in Go. It manages multiple instances of Claude Code, Aider, Codex, and Gemini in isolated git worktrees with separate tmux sessions, allowing parallel task execution.
+
+## Development Commands
+
+### Building and Testing
+
+```bash
+# Build the binary
+go build -v -o build/claude-squad
+
+# Run tests
+go test -v ./...
+
+# Run tests for a specific package
+go test -v ./session/...
+go test -v ./session/git/...
+go test -v ./ui/...
+
+# Build for specific platforms (as per CI)
+GOOS=linux GOARCH=amd64 go build -v -o build/linux_amd64/claude-squad
+GOOS=darwin GOARCH=arm64 go build -v -o build/darwin_arm64/claude-squad
+```
+
+### Running the Application
+
+```bash
+# Run directly
+go run main.go
+
+# Run with specific program
+go run main.go -p "aider --model ollama_chat/gemma3:1b"
+
+# Run with auto-yes mode (experimental)
+go run main.go -y
+
+# Show debug information
+go run main.go debug
+
+# Reset all stored instances
+go run main.go reset
+```
+
+## Architecture
+
+### Core Components
+
+**Instance Management** (`session/instance.go`, `session/storage.go`):
+- `Instance` is the central entity representing a running AI assistant session
+- Each instance has: title, git worktree, tmux session, branch, status (Running/Ready/Loading/Paused)
+- Instances can be paused (commits changes, removes worktree, keeps branch) and resumed
+- Storage handles serialization/deserialization of instances between runs
+
+**Git Worktree Integration** (`session/git/`):
+- Each instance gets an isolated git worktree in `~/.config/claude-squad/worktrees/`
+- Worktrees are created from the current repo with unique branches (prefix + sanitized session name)
+- Operations: Setup, Cleanup, Remove, Prune, IsDirty, CommitChanges, PushChanges
+- Diff tracking compares current state against base commit SHA
+
+**Tmux Session Management** (`session/tmux/tmux.go`):
+- Each instance runs in a dedicated tmux session prefixed with `claudesquad_`
+- PTY-based attachment enables resizing and input/output streaming
+- StatusMonitor tracks content changes using SHA256 hashing to detect when AI is working vs. waiting
+- Supports Claude, Aider, and Gemini with auto-detection of trust prompts
+- Mouse scrolling and history are enabled (10000 line limit)
+
+**UI Layer** (`app/app.go`, `ui/`):
+- Built with Bubble Tea TUI framework
+- Three-pane layout: List (30%) | Preview/Diff tabs (70%)
+- States: stateDefault, stateNew, statePrompt, stateHelp, stateConfirm
+- Key components: List, Menu, TabbedWindow (Preview + Diff), ErrBox, Overlays
+- Preview pane shows live tmux output; Diff pane shows git changes
+
+**Configuration** (`config/`):
+- Config stored in `~/.config/claude-squad/config.json`
+- State (instances) stored in `~/.config/claude-squad/state.json`
+- Configurable: DefaultProgram, BranchPrefix, AutoYes
+
+### Key Workflows
+
+**Creating a New Instance**:
+1. User presses `n` or `N` (with prompt)
+2. Instance created in memory (not started)
+3. User enters title
+4. Start() creates git worktree and tmux session
+5. Instance saved to storage
+6. UI switches to default state, shows help screen
+
+**Pausing/Resuming**:
+- Pause (`c`): Commits changes, removes worktree, kills tmux, sets status to Paused
+- Resume (`r`): Recreates worktree, restarts tmux session (or restores if still exists)
+- Branch and commit history are preserved
+
+**Attaching to Instance**:
+- User presses Enter on selected instance
+- Switches to raw terminal mode, streams tmux I/O
+- Ctrl-Q to detach (not Ctrl-D, which kills the session)
+
+**AutoYes Mode**:
+- Daemon process monitors instances and auto-presses Enter on prompts
+- Identified by detecting prompt strings (e.g., "No, and tell Claude what to do differently")
+
+## Important Implementation Details
+
+### Instance Lifecycle
+- `Instance.Start(firstTimeSetup bool)` handles both new instances and loading from storage
+- Always cleanup resources (worktree, tmux) in defer blocks with error accumulation
+- `started` flag prevents operations on uninitialized instances
+
+### Tmux PTY Management
+- Each tmux session requires a PTY (`ptmx`) for sizing control
+- On Attach: creates goroutines for I/O streaming and window size monitoring
+- On Detach: must close PTY, restore new one, cancel goroutines, wait for cleanup
+- DetachSafely vs. Detach: Safely version doesn't panic, used in Pause operation
+
+### Git Worktree Naming
+- Worktrees stored in config dir, not in repo, to avoid cluttering user's workspace
+- Names: `<sanitized_title>_<hex_timestamp>` for uniqueness
+- Branch names: `<configurable_prefix><sanitized_title>`
+- Always use absolute paths for reliability
+
+### Testing Patterns
+- Dependency injection for testability: `PtyFactory`, `cmd.Executor`
+- Test constructors: `NewTmuxSessionWithDeps`, `Instance.SetTmuxSession`
+- Mock git operations using test repos in temp directories
+
+### Concurrency
+- Preview updates every 100ms (previewTickMsg)
+- Metadata updates every 500ms (tickUpdateMetadataMessage) for status/diff
+- All UI updates go through Bubble Tea's message loop
+
+## Common Gotchas
+
+1. **Sanitization**: Session names are sanitized (spaces removed, dots replaced with underscores) before use in tmux
+2. **Exact Match**: Use `tmux has-session -t=name` (with `=`) for exact matching, not prefix matching
+3. **PTY Cleanup**: Always close and restore PTY after operations; never leave `t.ptmx` as nil after Start/Restore
+4. **Context Cancellation**: Attach goroutines must respect context for clean shutdown
+5. **Storage Sync**: Call `storage.SaveInstances()` after state changes (new instance, delete, pause)
+6. **Branch Checkout**: Cannot resume if branch is checked out elsewhere
+7. **History Capture**: Use `-S - -E -` for full scrollback history in tmux
+
+## Prerequisites
+
+- tmux
+- gh (GitHub CLI)
+- git (with worktree support)
+- Go 1.23+
+
+## Configuration Location
+
+Use `cs debug` (or `go run main.go debug`) to find config paths.

--- a/app/app.go
+++ b/app/app.go
@@ -36,6 +36,8 @@ const (
 	stateDefault state = iota
 	// stateNew is the state when the user is creating a new instance.
 	stateNew
+	// stateSelectProgram is the state when the user is selecting a program for the instance.
+	stateSelectProgram
 	// statePrompt is the state when the user is entering a prompt.
 	statePrompt
 	// stateHelp is the state when a help screen is displayed.
@@ -85,8 +87,10 @@ type home struct {
 	errBox *ui.ErrBox
 	// global spinner instance. we plumb this down to where it's needed
 	spinner spinner.Model
-	// textInputOverlay handles text input with state
+	// textInputOverlay handles multi-line text input with state
 	textInputOverlay *overlay.TextInputOverlay
+	// singleLineInputOverlay handles single-line text input with state
+	singleLineInputOverlay *overlay.SingleLineInputOverlay
 	// textOverlay displays text information
 	textOverlay *overlay.TextOverlay
 	// confirmationOverlay displays confirmation modals
@@ -158,6 +162,9 @@ func (m *home) updateHandleWindowSizeEvent(msg tea.WindowSizeMsg) {
 
 	if m.textInputOverlay != nil {
 		m.textInputOverlay.SetSize(int(float32(msg.Width)*0.6), int(float32(msg.Height)*0.4))
+	}
+	if m.singleLineInputOverlay != nil {
+		m.singleLineInputOverlay.SetSize(int(float32(msg.Width)*0.6), int(float32(msg.Height)*0.2))
 	}
 	if m.textOverlay != nil {
 		m.textOverlay.SetWidth(int(float32(msg.Width) * 0.6))
@@ -270,7 +277,7 @@ func (m *home) handleMenuHighlighting(msg tea.KeyMsg) (cmd tea.Cmd, returnEarly 
 		m.keySent = false
 		return nil, false
 	}
-	if m.state == statePrompt || m.state == stateHelp || m.state == stateConfirm {
+	if m.state == stateSelectProgram || m.state == statePrompt || m.state == stateHelp || m.state == stateConfirm {
 		return nil, false
 	}
 	// If it's in the global keymap, we should try to highlight it.
@@ -324,41 +331,23 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 
 		instance := m.list.GetInstances()[m.list.NumInstances()-1]
 		switch msg.Type {
-		// Start the instance (enable previews etc) and go back to the main menu state.
+		// After title entry, transition to program selection
 		case tea.KeyEnter:
 			if len(instance.Title) == 0 {
 				return m, m.handleError(fmt.Errorf("title cannot be empty"))
 			}
 
-			if err := instance.Start(true); err != nil {
-				m.list.Kill()
-				m.state = stateDefault
-				return m, m.handleError(err)
-			}
-			// Save after adding new instance
-			if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
-				return m, m.handleError(err)
-			}
-			// Instance added successfully, call the finalizer.
-			m.newInstanceFinalizer()
-			if m.autoYes {
-				instance.AutoYes = true
-			}
+			// Transition to program selection state
+			m.state = stateSelectProgram
+			m.menu.SetState(ui.StateSelectProgram)
+			// Initialize the single-line input overlay with default program as placeholder
+			m.singleLineInputOverlay = overlay.NewSingleLineInputOverlay(
+				"Enter program",
+				"e.g., claude, aider --model X",
+				m.program,
+			)
 
-			m.newInstanceFinalizer()
-			m.state = stateDefault
-			if m.promptAfterName {
-				m.state = statePrompt
-				m.menu.SetState(ui.StatePrompt)
-				// Initialize the text input overlay
-				m.textInputOverlay = overlay.NewTextInputOverlay("Enter prompt", "")
-				m.promptAfterName = false
-			} else {
-				m.menu.SetState(ui.StateDefault)
-				m.showHelpScreen(helpStart(instance), nil)
-			}
-
-			return m, tea.Batch(tea.WindowSize(), m.instanceChanged())
+			return m, tea.WindowSize()
 		case tea.KeyRunes:
 			if len(instance.Title) >= 32 {
 				return m, m.handleError(fmt.Errorf("title cannot be longer than 32 characters"))
@@ -391,6 +380,84 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 			)
 		default:
 		}
+		return m, nil
+	} else if m.state == stateSelectProgram {
+		// Handle program selection using SingleLineInputOverlay
+		shouldClose := m.singleLineInputOverlay.HandleKeyPress(msg)
+
+		// Check if the form was submitted or canceled
+		if shouldClose {
+			instance := m.list.GetInstances()[m.list.NumInstances()-1]
+
+			if m.singleLineInputOverlay.IsSubmitted() {
+				// Get the program value from the overlay
+				programValue := m.singleLineInputOverlay.GetValue()
+				if programValue == "" {
+					// If empty, use the default program
+					programValue = m.program
+				}
+
+				// Set the program on the instance
+				if err := instance.SetProgram(programValue); err != nil {
+					m.list.Kill()
+					m.state = stateDefault
+					m.singleLineInputOverlay = nil
+					return m, m.handleError(err)
+				}
+
+				// Start the instance
+				if err := instance.Start(true); err != nil {
+					m.list.Kill()
+					m.state = stateDefault
+					m.singleLineInputOverlay = nil
+					return m, m.handleError(err)
+				}
+
+				// Save after adding new instance
+				if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
+					m.singleLineInputOverlay = nil
+					return m, m.handleError(err)
+				}
+
+				// Instance added successfully, call the finalizer
+				m.newInstanceFinalizer()
+				if m.autoYes {
+					instance.AutoYes = true
+				}
+
+				// Close the overlay
+				m.singleLineInputOverlay = nil
+
+				// Transition to next state
+				if m.promptAfterName {
+					m.state = statePrompt
+					m.menu.SetState(ui.StatePrompt)
+					// Initialize the text input overlay for prompt
+					m.textInputOverlay = overlay.NewTextInputOverlay("Enter prompt", "")
+					m.promptAfterName = false
+					return m, tea.WindowSize()
+				} else {
+					m.state = stateDefault
+					m.menu.SetState(ui.StateDefault)
+					m.showHelpScreen(helpStart(instance), nil)
+					return m, tea.Batch(tea.WindowSize(), m.instanceChanged())
+				}
+			} else {
+				// Canceled - kill the instance and go back to default
+				m.list.Kill()
+				m.singleLineInputOverlay = nil
+				m.state = stateDefault
+				m.promptAfterName = false
+				return m, tea.Sequence(
+					tea.WindowSize(),
+					func() tea.Msg {
+						m.menu.SetState(ui.StateDefault)
+						return nil
+					},
+				)
+			}
+		}
+
 		return m, nil
 	} else if m.state == statePrompt {
 		// Use the new TextInputOverlay component to handle all key events
@@ -731,7 +798,12 @@ func (m *home) View() string {
 		m.errBox.String(),
 	)
 
-	if m.state == statePrompt {
+	if m.state == stateSelectProgram {
+		if m.singleLineInputOverlay == nil {
+			log.ErrorLog.Printf("single-line input overlay is nil")
+		}
+		return overlay.PlaceOverlay(0, 0, m.singleLineInputOverlay.Render(), mainView, true, true)
+	} else if m.state == statePrompt {
 		if m.textInputOverlay == nil {
 			log.ErrorLog.Printf("text input overlay is nil")
 		}

--- a/session/instance.go
+++ b/session/instance.go
@@ -355,6 +355,16 @@ func (i *Instance) SetTitle(title string) error {
 	return nil
 }
 
+// SetProgram sets the program for the instance. Returns an error if the instance has started.
+// We can't change the program once it's been used for a tmux session.
+func (i *Instance) SetProgram(program string) error {
+	if i.started {
+		return fmt.Errorf("cannot change program of a started instance")
+	}
+	i.Program = program
+	return nil
+}
+
 func (i *Instance) Paused() bool {
 	return i.Status == Paused
 }

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -39,6 +39,7 @@ const (
 	StateDefault MenuState = iota
 	StateEmpty
 	StateNewInstance
+	StateSelectProgram
 	StatePrompt
 )
 
@@ -55,6 +56,7 @@ type Menu struct {
 
 var defaultMenuOptions = []keys.KeyName{keys.KeyNew, keys.KeyPrompt, keys.KeyHelp, keys.KeyQuit}
 var newInstanceMenuOptions = []keys.KeyName{keys.KeySubmitName}
+var selectProgramMenuOptions = []keys.KeyName{keys.KeySubmitName}
 var promptMenuOptions = []keys.KeyName{keys.KeySubmitName}
 
 func NewMenu() *Menu {
@@ -83,8 +85,8 @@ func (m *Menu) SetState(state MenuState) {
 // SetInstance updates the current instance and refreshes menu options
 func (m *Menu) SetInstance(instance *session.Instance) {
 	m.instance = instance
-	// Only change the state if we're not in a special state (NewInstance or Prompt)
-	if m.state != StateNewInstance && m.state != StatePrompt {
+	// Only change the state if we're not in a special state (NewInstance, SelectProgram, or Prompt)
+	if m.state != StateNewInstance && m.state != StateSelectProgram && m.state != StatePrompt {
 		if m.instance != nil {
 			m.state = StateDefault
 		} else {
@@ -115,6 +117,8 @@ func (m *Menu) updateOptions() {
 		}
 	case StateNewInstance:
 		m.options = newInstanceMenuOptions
+	case StateSelectProgram:
+		m.options = selectProgramMenuOptions
 	case StatePrompt:
 		m.options = promptMenuOptions
 	}

--- a/ui/overlay/singleLineInput.go
+++ b/ui/overlay/singleLineInput.go
@@ -1,0 +1,116 @@
+package overlay
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// SingleLineInputOverlay represents a single-line text input overlay with state management.
+type SingleLineInputOverlay struct {
+	textinput     textinput.Model
+	Title         string
+	Submitted     bool
+	Canceled      bool
+	OnSubmit      func()
+	width, height int
+}
+
+// NewSingleLineInputOverlay creates a new single-line input overlay with the given title and initial value.
+func NewSingleLineInputOverlay(title string, placeholder string, initialValue string) *SingleLineInputOverlay {
+	ti := textinput.New()
+	ti.Placeholder = placeholder
+	ti.SetValue(initialValue)
+	ti.Focus()
+	ti.CharLimit = 256
+	ti.Width = 60
+
+	return &SingleLineInputOverlay{
+		textinput: ti,
+		Title:     title,
+		Submitted: false,
+		Canceled:  false,
+	}
+}
+
+func (s *SingleLineInputOverlay) SetSize(width, height int) {
+	s.width = width
+	s.height = height
+	// Set input width to fit within the overlay
+	s.textinput.Width = width - 10 // Account for padding and borders
+}
+
+// Init initializes the single-line input overlay model
+func (s *SingleLineInputOverlay) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+// View renders the model's view
+func (s *SingleLineInputOverlay) View() string {
+	return s.Render()
+}
+
+// HandleKeyPress processes a key press and updates the state accordingly.
+// Returns true if the overlay should be closed.
+func (s *SingleLineInputOverlay) HandleKeyPress(msg tea.KeyMsg) bool {
+	switch msg.Type {
+	case tea.KeyEsc:
+		s.Canceled = true
+		return true
+	case tea.KeyEnter:
+		// Submit on Enter
+		s.Submitted = true
+		if s.OnSubmit != nil {
+			s.OnSubmit()
+		}
+		return true
+	default:
+		s.textinput, _ = s.textinput.Update(msg)
+		return false
+	}
+}
+
+// GetValue returns the current value of the text input.
+func (s *SingleLineInputOverlay) GetValue() string {
+	return s.textinput.Value()
+}
+
+// IsSubmitted returns whether the form was submitted.
+func (s *SingleLineInputOverlay) IsSubmitted() bool {
+	return s.Submitted
+}
+
+// IsCanceled returns whether the form was canceled.
+func (s *SingleLineInputOverlay) IsCanceled() bool {
+	return s.Canceled
+}
+
+// SetOnSubmit sets a callback function for form submission.
+func (s *SingleLineInputOverlay) SetOnSubmit(onSubmit func()) {
+	s.OnSubmit = onSubmit
+}
+
+// Render renders the single-line input overlay.
+func (s *SingleLineInputOverlay) Render() string {
+	// Create styles
+	style := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("62")).
+		Padding(1, 2)
+
+	titleStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("62")).
+		Bold(true).
+		MarginBottom(1)
+
+	helpStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240")).
+		MarginTop(1)
+
+	// Build the view
+	content := titleStyle.Render(s.Title) + "\n"
+	content += s.textinput.View() + "\n"
+	content += helpStyle.Render("(Enter to submit, Esc to cancel)")
+
+	return style.Render(content)
+}


### PR DESCRIPTION
Previously all instances used the same program from config or command-line flag, preventing users from mixing different AI models (Claude, Aider with various models, etc.) in one session.

Add program selection step during instance creation flow. Users now enter title, select program (with placeholder hints showing default), then optionally enter prompt. Program input uses new single-line overlay for simpler UX compared to multi-line input.

Also add CLAUDE.md documentation for future Claude Code instances working in this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)