### PR TITLE
fix: Sanitize final branch name to handle invalid characters from Bra…

### DIFF
--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -44,8 +44,10 @@ func NewGitWorktreeFromStorage(repoPath string, worktreePath string, sessionName
 // NewGitWorktree creates a new GitWorktree instance
 func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, branchname string, err error) {
 	cfg := config.LoadConfig()
-	sanitizedName := sanitizeBranchName(sessionName)
-	branchName := fmt.Sprintf("%s%s", cfg.BranchPrefix, sanitizedName)
+	branchName := fmt.Sprintf("%s%s", cfg.BranchPrefix, sessionName)
+	// Sanitize the final branch name to handle invalid characters from any source
+	// (e.g., backslashes from Windows domain usernames like DOMAIN\user)
+	branchName = sanitizeBranchName(branchName)
 
 	// Convert repoPath to absolute path
 	absPath, err := filepath.Abs(repoPath)
@@ -65,7 +67,8 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 		return nil, "", err
 	}
 
-	worktreePath := filepath.Join(worktreeDir, sanitizedName)
+	// Use sanitized branch name for the worktree directory name
+	worktreePath := filepath.Join(worktreeDir, branchName)
 	worktreePath = worktreePath + "_" + fmt.Sprintf("%x", time.Now().UnixNano())
 
 	return &GitWorktree{


### PR DESCRIPTION
Fixes #220 

…nchPrefix

The git worktree creation was failing with:
"fatal: 'domain\username/session' is not a valid branch name"

Root cause: On Windows with domain accounts, user.Current().Username returns "DOMAIN\Username", which becomes the BranchPrefix (e.g., "domain\username/"). This prefix was concatenated with the session name, but the final combined branch name was never sanitized.

Solution: Apply sanitizeBranchName() once to the final concatenated branch name. This is simpler and more robust than sanitizing in multiple places, as it:
- Handles invalid chars from any source (BranchPrefix, session name, etc.)
- Single point of sanitization
- Works regardless of how BranchPrefix is generated

Example:
- BranchPrefix: "domain\john.doe/" (from Windows domain username)
- Session name: "my-session"
- Before: "domain\john.doe/my-session" ❌
- After:  "domainjohn.doe/my-session" ✓