### PR TITLE
feat: always display repository name in session list

### DIFF
--- a/session/instance.go
+++ b/session/instance.go
@@ -181,6 +181,15 @@ func (i *Instance) RepoName() (string, error) {
 	return i.gitWorktree.GetRepoName(), nil
 }
 
+// RepoNameFromPath returns the repository name from the instance's Path.
+// This can be used even when the instance has not been started.
+func (i *Instance) RepoNameFromPath() string {
+	if i.Path == "" {
+		return ""
+	}
+	return filepath.Base(i.Path)
+}
+
 func (i *Instance) SetStatus(status Status) {
 	i.Status = status
 }

--- a/ui/list.go
+++ b/ui/list.go
@@ -114,7 +114,7 @@ func (r *InstanceRenderer) setWidth(width int) {
 // ɹ and ɻ are other options.
 const branchIcon = "Ꮧ"
 
-func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, hasMultipleRepos bool) string {
+func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool) string {
 	prefix := fmt.Sprintf(" %d. ", idx)
 	if idx >= 10 {
 		prefix = prefix[:len(prefix)-1]
@@ -184,13 +184,18 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 	remainingWidth -= diffWidth
 
 	branch := i.Branch
-	if i.Started() && hasMultipleRepos {
-		repoName, err := i.RepoName()
-		if err != nil {
-			log.ErrorLog.Printf("could not get repo name in instance renderer: %v", err)
-		} else {
-			branch += fmt.Sprintf(" (%s)", repoName)
+	// Always show repository name for better identification
+	var repoName string
+	if i.Started() {
+		if rn, err := i.RepoName(); err == nil {
+			repoName = rn
 		}
+	} else {
+		// For not-started instances, get repo name from Path
+		repoName = i.RepoNameFromPath()
+	}
+	if repoName != "" {
+		branch += fmt.Sprintf(" (%s)", repoName)
 	}
 	// Don't show branch if there's no space for it. Or show ellipsis if it's too long.
 	branchWidth := runewidth.StringWidth(branch)
@@ -253,7 +258,7 @@ func (l *List) String() string {
 
 	// Render the list.
 	for i, item := range l.items {
-		b.WriteString(l.renderer.Render(item, i+1, i == l.selectedIdx, len(l.repos) > 1))
+		b.WriteString(l.renderer.Render(item, i+1, i == l.selectedIdx))
 		if i != len(l.items)-1 {
 			b.WriteString("\n\n")
 		}


### PR DESCRIPTION
## Summary

- Always display the repository name in the session list view, regardless of whether multiple repositories are in use
- Add `RepoNameFromPath()` method to `Instance` for retrieving repository name even when the instance hasn't started yet
- Repository name is now shown in parentheses after the branch name for better session identification

## Problem

When working with multiple repositories, it was difficult to identify which repository each session belonged to because repository names were only displayed when `hasMultipleRepos` was true. Users had to attach to a session and run `pwd` or `git remote -v` to identify the repository.

## Solution

- Remove the `hasMultipleRepos` condition from `InstanceRenderer.Render()`
- Add a new method `RepoNameFromPath()` that extracts the repository name from the instance's `Path` field
- This allows displaying the repository name even for sessions that haven't been started yet

## Changes

- `session/instance.go`: Added `RepoNameFromPath()` method
- `ui/list.go`: Modified `Render()` to always show repository name

## Before/After

**Before:** Repository name only shown when multiple repos detected
```
● fix-auth       y.sasajima/fix-auth
```

**After:** Repository name always shown
```
● fix-auth       y.sasajima/fix-auth (ernie-call-api)
```

Closes #238