### PR TITLE
feat: support CLAUDE_SQUAD_HOME environment variable for custom config directory

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,10 +15,28 @@ import (
 const (
 	ConfigFileName = "config.json"
 	defaultProgram = "claude"
+	// EnvConfigDir is the environment variable name for overriding the config directory
+	EnvConfigDir = "CLAUDE_SQUAD_HOME"
 )
 
-// GetConfigDir returns the path to the application's configuration directory
+// GetConfigDir returns the path to the application's configuration directory.
+// It first checks for the CLAUDE_SQUAD_HOME environment variable, and if set,
+// uses that as the config directory. Otherwise, it defaults to ~/.claude-squad.
 func GetConfigDir() (string, error) {
+	// Check for environment variable override
+	if envDir := os.Getenv(EnvConfigDir); envDir != "" {
+		// Expand ~ if present
+		if strings.HasPrefix(envDir, "~") {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("failed to expand home directory: %w", err)
+			}
+			envDir = filepath.Join(homeDir, envDir[2:])
+		}
+		return envDir, nil
+	}
+
+	// Default behavior
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get config home directory: %w", err)


### PR DESCRIPTION
## Summary

Add support for the `CLAUDE_SQUAD_HOME` environment variable to allow users to customize the configuration directory location.

Closes #245

## Changes

- Add `EnvConfigDir` constant for the environment variable name
- Modify `GetConfigDir()` to check for the environment variable first
- Support tilde expansion (`~/`) in the environment variable value
- Add comprehensive tests for the new functionality

## Use Cases

**1. Per-repository session isolation:**
```bash
#!/bin/bash
REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
REPO_NAME=$(basename "$REPO_ROOT")
export CLAUDE_SQUAD_HOME="$HOME/.claude-squad/repos/$REPO_NAME"
exec claude-squad "$@"
```

**2. Project-specific configurations:**
```bash
export CLAUDE_SQUAD_HOME="$PWD/.claude-squad"
```

**3. Testing/development:**
```bash
CLAUDE_SQUAD_HOME=/tmp/cs-test claude-squad
```

## Benefits

- **Backwards compatible**: Default behavior unchanged when env var is not set
- **Simple implementation**: Minimal code change required
- **Flexible**: Users can implement their own isolation strategies
- **Reduces state corruption impact**: Issues in one config dir don't affect others

## Test plan

- [x] `go build .` succeeds
- [x] `go test ./config/...` passes
- [x] Manual verification with `CLAUDE_SQUAD_HOME=/tmp/test-cs ./claude-squad debug`
- [x] Tilde expansion works correctly

## Verification

```
$ CLAUDE_SQUAD_HOME=/tmp/test-cs ./claude-squad debug
Config: /tmp/test-cs/config.json
{
  "default_program": "/opt/homebrew/bin/claude",
  "auto_yes": false,
  "daemon_poll_interval": 1000,
  "branch_prefix": "y.sasajima/"
}
```