### PR TITLE
Add Windows Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 claude-squad
 **.DS_Store
 cs
+
+# Windows
+*.exe
+Thumbs.db
+Desktop.ini

--- a/app/app.go
+++ b/app/app.go
@@ -612,7 +612,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 			return m, nil
 		}
 		selected := m.list.GetSelectedInstance()
-		if selected == nil || selected.Paused() || !selected.TmuxAlive() {
+		if selected == nil || selected.Paused() || !selected.SessionAlive() {
 			return m, nil
 		}
 		// Show help screen before attaching

--- a/app/help.go
+++ b/app/help.go
@@ -67,7 +67,7 @@ func (h helpTypeInstanceStart) toContent() string {
 		descStyle.Render("New session created:"),
 		descStyle.Render(fmt.Sprintf("• Git branch: %s (isolated worktree)",
 			lipgloss.NewStyle().Bold(true).Render(h.instance.Branch))),
-		descStyle.Render(fmt.Sprintf("• %s running in background tmux session",
+		descStyle.Render(fmt.Sprintf("• %s running in background terminal session",
 			lipgloss.NewStyle().Bold(true).Render(h.instance.Program))),
 		"",
 		headerStyle.Render("Managing:"),

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,25 @@
+@echo off
+setlocal
+
+cd /d "%~dp0"
+
+:: Find Go on PATH or in standard install locations
+where go >nul 2>&1
+if %errorlevel% equ 0 (
+    set "GO=go"
+) else if exist "C:\Program Files\Go\bin\go.exe" (
+    set "GO=C:\Program Files\Go\bin\go.exe"
+) else (
+    echo Error: Go is not installed or not in PATH.
+    echo Install from https://go.dev/dl/
+    exit /b 1
+)
+
+echo Building claude-squad...
+"%GO%" build -o cs.exe .
+if %errorlevel% neq 0 (
+    echo Build failed.
+    exit /b 1
+)
+
+echo Build successful: %~dp0cs.exe

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")"
+
+echo "Building claude-squad..."
+go build -o cs .
+
+echo "Build successful: $(pwd)/cs"

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -10,7 +10,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -71,9 +70,9 @@ func RunDaemon(cfg *config.Config) error {
 		}
 	}()
 
-	// Notify on SIGINT (Ctrl+C) and SIGTERM. Save instances before
+	// Notify on interrupt (Ctrl+C). Save instances before exiting.
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigChan, os.Interrupt)
 	sig := <-sigChan
 	log.InfoLog.Printf("received signal %s", sig.String())
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	dario.cat/mergo v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.5 // indirect
+	github.com/UserExistsError/conpty v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.5 h1:eoAQfK2dwL+tFSFpr7TbOaPNUbPiJj4fLYwwGE1FQO4=
 github.com/ProtonMail/go-crypto v1.1.5/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
+github.com/UserExistsError/conpty v0.1.4 h1:+3FhJhiqhyEJa+K5qaK3/w6w+sN3Nh9O9VbJyBS02to=
+github.com/UserExistsError/conpty v0.1.4/go.mod h1:PDglKIkX3O/2xVk0MV9a6bCWxRmPVfxqZoTG/5sSd9I=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -134,6 +136,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal
+
+set "INSTALL_DIR=%LOCALAPPDATA%\bin"
+set "SOURCE=%~dp0cs.exe"
+
+:: Build if cs.exe doesn't exist
+if not exist "%SOURCE%" (
+    echo cs.exe not found, building...
+    call "%~dp0build.bat"
+    if %errorlevel% neq 0 exit /b 1
+)
+
+:: Create install directory
+if not exist "%INSTALL_DIR%" (
+    mkdir "%INSTALL_DIR%"
+    echo Created %INSTALL_DIR%
+)
+
+:: Copy binary
+copy /y "%SOURCE%" "%INSTALL_DIR%\cs.exe" >nul
+if %errorlevel% neq 0 (
+    echo Failed to copy cs.exe to %INSTALL_DIR%
+    exit /b 1
+)
+echo Installed to %INSTALL_DIR%\cs.exe
+
+:: Add to user PATH if not already there
+echo %PATH% | findstr /i /c:"%INSTALL_DIR%" >nul
+if %errorlevel% neq 0 (
+    for /f "tokens=2*" %%A in ('reg query "HKCU\Environment" /v Path 2^>nul') do set "USER_PATH=%%B"
+    setx PATH "%USER_PATH%;%INSTALL_DIR%" >nul
+    echo Added %INSTALL_DIR% to PATH. Restart your terminal to use "cs" globally.
+) else (
+    echo %INSTALL_DIR% is already in PATH.
+)
+
+echo Done. Run "cs" to start claude-squad.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,315 @@
+# Claude Squad Windows Installation Script
+# PowerShell version of install.sh
+
+param(
+    [string]$Name = "cs",
+    [string]$Version = "latest",
+    [string]$BinDir = "$env:LOCALAPPDATA\bin"
+)
+
+function Write-Status {
+    param([string]$Message, [string]$Type = "Info")
+    $color = switch ($Type) {
+        "Success" { "Green" }
+        "Warning" { "Yellow" }
+        "Error" { "Red" }
+        default { "White" }
+    }
+    Write-Host $Message -ForegroundColor $color
+}
+
+function Test-CommandExists {
+    param([string]$Command)
+    $null -ne (Get-Command $Command -ErrorAction SilentlyContinue)
+}
+
+function Install-GitHubCLI {
+    Write-Status "Installing GitHub CLI..." "Info"
+
+    if (Test-CommandExists "winget") {
+        try {
+            winget install --id GitHub.cli --silent
+            Write-Status "GitHub CLI installed successfully via winget" "Success"
+            return $true
+        }
+        catch {
+            Write-Status "Failed to install GitHub CLI via winget: $($_.Exception.Message)" "Warning"
+        }
+    }
+
+    if (Test-CommandExists "choco") {
+        try {
+            choco install gh -y
+            Write-Status "GitHub CLI installed successfully via chocolatey" "Success"
+            return $true
+        }
+        catch {
+            Write-Status "Failed to install GitHub CLI via chocolatey: $($_.Exception.Message)" "Warning"
+        }
+    }
+
+    Write-Status "Please install GitHub CLI manually from https://cli.github.com/" "Warning"
+    return $false
+}
+
+function Install-WindowsTerminal {
+    Write-Status "Installing Windows Terminal..." "Info"
+
+    if (Test-CommandExists "winget") {
+        try {
+            winget install --id Microsoft.WindowsTerminal --silent
+            Write-Status "Windows Terminal installed successfully" "Success"
+            return $true
+        }
+        catch {
+            Write-Status "Failed to install Windows Terminal: $($_.Exception.Message)" "Warning"
+        }
+    }
+
+    Write-Status "Please install Windows Terminal from Microsoft Store" "Warning"
+    return $false
+}
+
+function Test-Dependencies {
+    Write-Status "Checking dependencies..." "Info"
+
+    $allDepsOk = $true
+
+    # Check GitHub CLI
+    if (-not (Test-CommandExists "gh")) {
+        Write-Status "GitHub CLI not found. Installing..." "Warning"
+        if (-not (Install-GitHubCLI)) {
+            $allDepsOk = $false
+        }
+    } else {
+        Write-Status "GitHub CLI is already installed" "Success"
+    }
+
+    # Check Windows Terminal (optional but recommended)
+    if (-not (Test-CommandExists "wt")) {
+        Write-Status "Windows Terminal not found. Installing..." "Warning"
+        Install-WindowsTerminal  # Don't fail if this doesn't work
+    } else {
+        Write-Status "Windows Terminal is already installed" "Success"
+    }
+
+    return $allDepsOk
+}
+
+function Get-LatestVersion {
+    try {
+        $apiUrl = "https://api.github.com/repos/smtg-ai/claude-squad/releases"
+        $releases = Invoke-RestMethod -Uri $apiUrl -Method Get
+
+        if ($releases -and $releases.Count -gt 0) {
+            $latestVersion = $releases[0].tag_name -replace "^v", ""
+            return $latestVersion
+        }
+        else {
+            throw "No releases found"
+        }
+    }
+    catch {
+        Write-Status "Failed to get latest version: $($_.Exception.Message)" "Error"
+        throw
+    }
+}
+
+function Get-Architecture {
+    $arch = [System.Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE")
+    switch ($arch) {
+        "AMD64" { return "amd64" }
+        "ARM64" { return "arm64" }
+        default { return "amd64" }
+    }
+}
+
+function Download-Release {
+    param(
+        [string]$Version,
+        [string]$Architecture,
+        [string]$TempDir
+    )
+
+    $platform = "windows"
+    $archiveExt = ".zip"
+
+    $archiveName = "claude-squad_${Version}_${platform}_${Architecture}${archiveExt}"
+    $downloadUrl = "https://github.com/smtg-ai/claude-squad/releases/download/v${Version}/${archiveName}"
+    $downloadPath = Join-Path $TempDir $archiveName
+
+    Write-Status "Downloading from: $downloadUrl" "Info"
+
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $downloadPath -UseBasicParsing
+        Write-Status "Download completed" "Success"
+        return $downloadPath
+    }
+    catch {
+        Write-Status "Download failed: $($_.Exception.Message)" "Error"
+        throw
+    }
+}
+
+function Extract-Archive {
+    param(
+        [string]$ArchivePath,
+        [string]$ExtractDir
+    )
+
+    try {
+        Expand-Archive -Path $ArchivePath -DestinationPath $ExtractDir -Force
+        Write-Status "Archive extracted successfully" "Success"
+        return $true
+    }
+    catch {
+        Write-Status "Failed to extract archive: $($_.Exception.Message)" "Error"
+        return $false
+    }
+}
+
+function Install-Binary {
+    param(
+        [string]$ExtractDir,
+        [string]$BinDir,
+        [string]$InstallName
+    )
+
+    $sourcePath = Join-Path $ExtractDir "claude-squad.exe"
+    $targetPath = Join-Path $BinDir "$InstallName.exe"
+
+    # Create bin directory if it doesn't exist
+    if (-not (Test-Path $BinDir)) {
+        New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+        Write-Status "Created directory: $BinDir" "Info"
+    }
+
+    # Remove existing binary if upgrading
+    if (Test-Path $targetPath) {
+        Remove-Item $targetPath -Force
+        Write-Status "Removed existing binary: $targetPath" "Info"
+    }
+
+    # Copy new binary
+    try {
+        Copy-Item $sourcePath $targetPath -Force
+        Write-Status "Binary installed to: $targetPath" "Success"
+        return $true
+    }
+    catch {
+        Write-Status "Failed to install binary: $($_.Exception.Message)" "Error"
+        return $false
+    }
+}
+
+function Add-ToPath {
+    param([string]$BinDir)
+
+    $currentPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+
+    if ($currentPath -notlike "*$BinDir*") {
+        $newPath = "$currentPath;$BinDir"
+        [Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+        Write-Status "Added $BinDir to PATH" "Success"
+        Write-Status "Please restart your terminal or run: `$env:PATH += ';$BinDir'" "Info"
+    } else {
+        Write-Status "$BinDir is already in PATH" "Info"
+    }
+}
+
+function Test-Installation {
+    param([string]$BinDir, [string]$InstallName)
+
+    $binaryPath = Join-Path $BinDir "$InstallName.exe"
+
+    if (Test-Path $binaryPath) {
+        try {
+            # Add to current session PATH for testing
+            $env:PATH += ";$BinDir"
+            $versionOutput = & $binaryPath version 2>&1
+            Write-Status "Installation successful!" "Success"
+            Write-Status "Version: $versionOutput" "Info"
+            return $true
+        }
+        catch {
+            Write-Status "Binary exists but failed to run: $($_.Exception.Message)" "Error"
+            return $false
+        }
+    } else {
+        Write-Status "Binary not found at: $binaryPath" "Error"
+        return $false
+    }
+}
+
+# Main installation process
+function Main {
+    Write-Status "Claude Squad Windows Installer" "Info"
+    Write-Status "================================" "Info"
+
+    # Check dependencies
+    if (-not (Test-Dependencies)) {
+        Write-Status "Dependency check failed. Please install missing dependencies and try again." "Error"
+        exit 1
+    }
+
+    # Get version
+    if ($Version -eq "latest") {
+        try {
+            $Version = Get-LatestVersion
+            Write-Status "Latest version: $Version" "Info"
+        }
+        catch {
+            Write-Status "Failed to get latest version. Please specify a version manually." "Error"
+            exit 1
+        }
+    }
+
+    # Detect architecture
+    $architecture = Get-Architecture
+    Write-Status "Detected architecture: $architecture" "Info"
+
+    # Create temporary directory
+    $tempDir = Join-Path $env:TEMP "claude-squad-install"
+    if (Test-Path $tempDir) {
+        Remove-Item $tempDir -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+    try {
+        # Download release
+        $archivePath = Download-Release -Version $Version -Architecture $architecture -TempDir $tempDir
+
+        # Extract archive
+        $extractDir = Join-Path $tempDir "extract"
+        if (-not (Extract-Archive -ArchivePath $archivePath -ExtractDir $extractDir)) {
+            exit 1
+        }
+
+        # Install binary
+        if (-not (Install-Binary -ExtractDir $extractDir -BinDir $BinDir -InstallName $Name)) {
+            exit 1
+        }
+
+        # Add to PATH
+        Add-ToPath -BinDir $BinDir
+
+        # Test installation
+        if (Test-Installation -BinDir $BinDir -InstallName $Name) {
+            Write-Status "" "Info"
+            Write-Status "Installation completed successfully!" "Success"
+            Write-Status "You can now use '$Name' command" "Info"
+        } else {
+            Write-Status "Installation verification failed" "Error"
+            exit 1
+        }
+    }
+    finally {
+        # Cleanup
+        if (Test-Path $tempDir) {
+            Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+# Run main function
+Main

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"claude-squad/log"
 	"claude-squad/session"
 	"claude-squad/session/git"
-	"claude-squad/session/tmux"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -92,10 +91,10 @@ var (
 			}
 			fmt.Println("Storage has been reset successfully")
 
-			if err := tmux.CleanupSessions(cmd2.MakeExecutor()); err != nil {
-				return fmt.Errorf("failed to cleanup tmux sessions: %w", err)
+			if err := session.CleanupTerminalSessions(cmd2.MakeExecutor()); err != nil {
+				return fmt.Errorf("failed to cleanup terminal sessions: %w", err)
 			}
-			fmt.Println("Tmux sessions have been cleaned up")
+			fmt.Println("Terminal sessions have been cleaned up")
 
 			if err := git.CleanupWorktrees(); err != nil {
 				return fmt.Errorf("failed to cleanup worktrees: %w", err)

--- a/session/instance_test.go
+++ b/session/instance_test.go
@@ -1,0 +1,515 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTerminalSession implements the TerminalSession interface for testing.
+type mockTerminalSession struct {
+	startCalled    bool
+	startErr       error
+	restoreCalled  bool
+	restoreErr     error
+	closeCalled    bool
+	closeErr       error
+	captureContent string
+	captureErr     error
+	captureOptContent string
+	captureOptErr     error
+	hasUpdatedVal  bool
+	hasPromptVal   bool
+	tapEnterCalled bool
+	tapEnterErr    error
+	sendKeysCalled bool
+	sendKeysInput  string
+	sendKeysErr    error
+	attachCh       chan struct{}
+	attachErr      error
+	setSizeCalled  bool
+	setSizeErr     error
+	sessionExists  bool
+	detachCalled   bool
+	detachErr      error
+}
+
+func (m *mockTerminalSession) Start(workDir string) error {
+	m.startCalled = true
+	return m.startErr
+}
+
+func (m *mockTerminalSession) Restore() error {
+	m.restoreCalled = true
+	return m.restoreErr
+}
+
+func (m *mockTerminalSession) Close() error {
+	m.closeCalled = true
+	return m.closeErr
+}
+
+func (m *mockTerminalSession) CapturePaneContent() (string, error) {
+	return m.captureContent, m.captureErr
+}
+
+func (m *mockTerminalSession) CapturePaneContentWithOptions(start, end string) (string, error) {
+	return m.captureOptContent, m.captureOptErr
+}
+
+func (m *mockTerminalSession) HasUpdated() (bool, bool) {
+	return m.hasUpdatedVal, m.hasPromptVal
+}
+
+func (m *mockTerminalSession) TapEnter() error {
+	m.tapEnterCalled = true
+	return m.tapEnterErr
+}
+
+func (m *mockTerminalSession) SendKeys(keys string) error {
+	m.sendKeysCalled = true
+	m.sendKeysInput = keys
+	return m.sendKeysErr
+}
+
+func (m *mockTerminalSession) Attach() (chan struct{}, error) {
+	if m.attachErr != nil {
+		return nil, m.attachErr
+	}
+	if m.attachCh == nil {
+		m.attachCh = make(chan struct{})
+	}
+	return m.attachCh, nil
+}
+
+func (m *mockTerminalSession) SetDetachedSize(width, height int) error {
+	m.setSizeCalled = true
+	return m.setSizeErr
+}
+
+func (m *mockTerminalSession) DoesSessionExist() bool {
+	return m.sessionExists
+}
+
+func (m *mockTerminalSession) DetachSafely() error {
+	m.detachCalled = true
+	return m.detachErr
+}
+
+func TestSetTerminalSession(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	mock := &mockTerminalSession{}
+	instance.SetTerminalSession(mock)
+
+	assert.Equal(t, mock, instance.termSession)
+}
+
+func TestSessionAlive(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	mock := &mockTerminalSession{sessionExists: true}
+	instance.SetTerminalSession(mock)
+
+	assert.True(t, instance.SessionAlive())
+
+	mock.sessionExists = false
+	assert.False(t, instance.SessionAlive())
+}
+
+func TestPreview_NotStarted(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	content, err := instance.Preview()
+	assert.NoError(t, err)
+	assert.Equal(t, "", content)
+}
+
+func TestPreview_Paused(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	instance.Status = Paused
+	mock := &mockTerminalSession{captureContent: "should not see this"}
+	instance.SetTerminalSession(mock)
+
+	content, err := instance.Preview()
+	assert.NoError(t, err)
+	assert.Equal(t, "", content)
+}
+
+func TestPreview_Started(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	instance.Status = Running
+	mock := &mockTerminalSession{captureContent: "hello world"}
+	instance.SetTerminalSession(mock)
+
+	content, err := instance.Preview()
+	assert.NoError(t, err)
+	assert.Equal(t, "hello world", content)
+}
+
+func TestHasUpdated_NotStarted(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	updated, hasPrompt := instance.HasUpdated()
+	assert.False(t, updated)
+	assert.False(t, hasPrompt)
+}
+
+func TestHasUpdated_Started(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	mock := &mockTerminalSession{hasUpdatedVal: true, hasPromptVal: true}
+	instance.SetTerminalSession(mock)
+
+	updated, hasPrompt := instance.HasUpdated()
+	assert.True(t, updated)
+	assert.True(t, hasPrompt)
+}
+
+func TestTapEnter_NotStarted(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	mock := &mockTerminalSession{}
+	instance.SetTerminalSession(mock)
+	instance.AutoYes = true
+
+	// Should not tap enter when not started
+	instance.TapEnter()
+	assert.False(t, mock.tapEnterCalled)
+}
+
+func TestTapEnter_AutoYesDisabled(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	instance.AutoYes = false
+	mock := &mockTerminalSession{}
+	instance.SetTerminalSession(mock)
+
+	// Should not tap enter when AutoYes is false
+	instance.TapEnter()
+	assert.False(t, mock.tapEnterCalled)
+}
+
+func TestTapEnter_AutoYesEnabled(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	instance.AutoYes = true
+	mock := &mockTerminalSession{}
+	instance.SetTerminalSession(mock)
+
+	instance.TapEnter()
+	assert.True(t, mock.tapEnterCalled)
+}
+
+func TestAttach_NotStarted(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	ch, err := instance.Attach()
+	assert.Error(t, err)
+	assert.Nil(t, ch)
+}
+
+func TestAttach_Started(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	expectedCh := make(chan struct{})
+	mock := &mockTerminalSession{attachCh: expectedCh}
+	instance.SetTerminalSession(mock)
+
+	ch, err := instance.Attach()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedCh, ch)
+}
+
+func TestSetPreviewSize_NotStarted(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	err = instance.SetPreviewSize(80, 24)
+	assert.Error(t, err)
+}
+
+func TestSetPreviewSize_Paused(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	instance.Status = Paused
+	mock := &mockTerminalSession{}
+	instance.SetTerminalSession(mock)
+
+	err = instance.SetPreviewSize(80, 24)
+	assert.Error(t, err)
+	assert.False(t, mock.setSizeCalled)
+}
+
+func TestSetPreviewSize_Running(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	instance.Status = Running
+	mock := &mockTerminalSession{}
+	instance.SetTerminalSession(mock)
+
+	err = instance.SetPreviewSize(80, 24)
+	assert.NoError(t, err)
+	assert.True(t, mock.setSizeCalled)
+}
+
+func TestSendKeys_NotStarted(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	err = instance.SendKeys("hello")
+	assert.Error(t, err)
+}
+
+func TestSendKeys_Paused(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	instance.Status = Paused
+	mock := &mockTerminalSession{}
+	instance.SetTerminalSession(mock)
+
+	err = instance.SendKeys("hello")
+	assert.Error(t, err)
+	assert.False(t, mock.sendKeysCalled)
+}
+
+func TestSendKeys_Running(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	instance.Status = Running
+	mock := &mockTerminalSession{}
+	instance.SetTerminalSession(mock)
+
+	err = instance.SendKeys("hello")
+	assert.NoError(t, err)
+	assert.True(t, mock.sendKeysCalled)
+	assert.Equal(t, "hello", mock.sendKeysInput)
+}
+
+func TestSendPrompt_NotStarted(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	err = instance.SendPrompt("hello")
+	assert.Error(t, err)
+}
+
+func TestSendPrompt_NilSession(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	instance.termSession = nil
+
+	err = instance.SendPrompt("hello")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "terminal session not initialized")
+}
+
+func TestSendPrompt_Success(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	mock := &mockTerminalSession{}
+	instance.SetTerminalSession(mock)
+
+	err = instance.SendPrompt("hello")
+	assert.NoError(t, err)
+	assert.True(t, mock.sendKeysCalled)
+	assert.Equal(t, "hello", mock.sendKeysInput)
+	assert.True(t, mock.tapEnterCalled)
+}
+
+func TestPreviewFullHistory_NotStarted(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	content, err := instance.PreviewFullHistory()
+	assert.NoError(t, err)
+	assert.Equal(t, "", content)
+}
+
+func TestPreviewFullHistory_Paused(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	instance.Status = Paused
+
+	content, err := instance.PreviewFullHistory()
+	assert.NoError(t, err)
+	assert.Equal(t, "", content)
+}
+
+func TestPreviewFullHistory_Running(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	instance.Status = Running
+	mock := &mockTerminalSession{captureOptContent: "full history here"}
+	instance.SetTerminalSession(mock)
+
+	content, err := instance.PreviewFullHistory()
+	assert.NoError(t, err)
+	assert.Equal(t, "full history here", content)
+}
+
+func TestKill_NotStarted(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	// Kill on an unstarted instance should succeed
+	err = instance.Kill()
+	assert.NoError(t, err)
+}
+
+func TestKill_Started(t *testing.T) {
+	instance, err := NewInstance(InstanceOptions{
+		Title:   "test",
+		Path:    t.TempDir(),
+		Program: "bash",
+	})
+	require.NoError(t, err)
+
+	instance.started = true
+	mock := &mockTerminalSession{}
+	instance.SetTerminalSession(mock)
+
+	err = instance.Kill()
+	assert.NoError(t, err)
+	assert.True(t, mock.closeCalled)
+}
+
+// Compile-time check: mockTerminalSession satisfies TerminalSession.
+var _ TerminalSession = (*mockTerminalSession)(nil)

--- a/session/terminal.go
+++ b/session/terminal.go
@@ -1,0 +1,18 @@
+package session
+
+// TerminalSession is the interface for managing terminal sessions.
+// On Unix this is backed by tmux, on Windows by Windows Terminal.
+type TerminalSession interface {
+	Start(workDir string) error
+	Restore() error
+	Close() error
+	CapturePaneContent() (string, error)
+	CapturePaneContentWithOptions(start, end string) (string, error)
+	HasUpdated() (updated bool, hasPrompt bool)
+	TapEnter() error
+	SendKeys(keys string) error
+	Attach() (chan struct{}, error)
+	SetDetachedSize(width, height int) error
+	DoesSessionExist() bool
+	DetachSafely() error
+}

--- a/session/terminal_unix.go
+++ b/session/terminal_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package session
+
+import (
+	"claude-squad/cmd"
+	"claude-squad/session/tmux"
+)
+
+// NewTerminalSession creates a new terminal session for the current platform.
+// On Unix, this returns a tmux-backed session.
+func NewTerminalSession(name, program string) TerminalSession {
+	return tmux.NewTmuxSession(name, program)
+}
+
+// NewTerminalSessionWithDeps creates a new terminal session with provided dependencies for testing.
+func NewTerminalSessionWithDeps(name, program string, ptyFactory tmux.PtyFactory, cmdExec cmd.Executor) TerminalSession {
+	return tmux.NewTmuxSessionWithDeps(name, program, ptyFactory, cmdExec)
+}
+
+// CleanupTerminalSessions cleans up all terminal sessions created by claude-squad.
+func CleanupTerminalSessions(cmdExec cmd.Executor) error {
+	return tmux.CleanupSessions(cmdExec)
+}

--- a/session/terminal_windows.go
+++ b/session/terminal_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package session
+
+import (
+	"claude-squad/cmd"
+	"claude-squad/session/winterminal"
+)
+
+// NewTerminalSession creates a new terminal session for the current platform.
+// On Windows, this returns a Windows Terminal-backed session.
+func NewTerminalSession(name, program string) TerminalSession {
+	return winterminal.NewWindowsTerminalSession(name, program)
+}
+
+// NewTerminalSessionWithDeps creates a new terminal session with provided dependencies for testing.
+func NewTerminalSessionWithDeps(name, program string, cmdExec cmd.Executor) TerminalSession {
+	return winterminal.NewWindowsTerminalSessionWithDeps(name, program, cmdExec)
+}
+
+// CleanupTerminalSessions cleans up all terminal sessions created by claude-squad.
+func CleanupTerminalSessions(cmdExec cmd.Executor) error {
+	return winterminal.CleanupSessions(cmdExec)
+}

--- a/session/winterminal/winterminal.go
+++ b/session/winterminal/winterminal.go
@@ -1,0 +1,502 @@
+//go:build windows
+
+package winterminal
+
+import (
+	"bytes"
+	"claude-squad/cmd"
+	"claude-squad/log"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/UserExistsError/conpty"
+	"golang.org/x/term"
+)
+
+const (
+	programClaude = "claude"
+	programAider  = "aider"
+	programGemini = "gemini"
+
+	defaultCols = 80
+	defaultRows = 24
+)
+
+// WindowsTerminalSession manages an interactive terminal session on Windows
+// using the ConPTY (Pseudo Console) API via the conpty library.
+type WindowsTerminalSession struct {
+	sessionName   string
+	sanitizedName string
+	program       string
+
+	// ConPTY handle
+	cpty *conpty.ConPty
+
+	// Screen buffer: accumulated output lines
+	lines   []string
+	partial string
+	bufMu   sync.RWMutex
+
+	// Content monitoring for HasUpdated
+	prevHash []byte
+
+	// Terminal dimensions
+	width  int
+	height int
+
+	// Session state
+	isRunning bool
+	mu        sync.RWMutex
+
+	// Output reader goroutine lifecycle
+	outputDone chan struct{}
+
+	// Attach state
+	attached atomic.Bool
+	attachCh chan struct{}
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wg       *sync.WaitGroup
+
+	cmdExec cmd.Executor
+}
+
+// sanitizeName cleans up the session name for use as an identifier.
+func sanitizeName(name string) string {
+	str := strings.ReplaceAll(name, " ", "_")
+	str = strings.ReplaceAll(str, "-", "_")
+	str = strings.ReplaceAll(str, ".", "_")
+	return "claudesquad_" + str
+}
+
+// NewWindowsTerminalSession creates a new Windows Terminal session.
+func NewWindowsTerminalSession(sessionName, program string) *WindowsTerminalSession {
+	return &WindowsTerminalSession{
+		sessionName:   sessionName,
+		sanitizedName: sanitizeName(sessionName),
+		program:       program,
+		cmdExec:       cmd.MakeExecutor(),
+	}
+}
+
+// NewWindowsTerminalSessionWithDeps creates a session with a custom executor (for testing).
+func NewWindowsTerminalSessionWithDeps(sessionName, program string, cmdExec cmd.Executor) *WindowsTerminalSession {
+	return &WindowsTerminalSession{
+		sessionName:   sessionName,
+		sanitizedName: sanitizeName(sessionName),
+		program:       program,
+		cmdExec:       cmdExec,
+	}
+}
+
+// Start creates a ConPTY, launches the program inside it, and begins
+// capturing output into the screen buffer.
+func (w *WindowsTerminalSession) Start(workDir string) error {
+	w.mu.Lock()
+	if w.isRunning {
+		w.mu.Unlock()
+		return fmt.Errorf("session already running: %s", w.sanitizedName)
+	}
+
+	cols, rows := w.width, w.height
+	if cols <= 0 {
+		cols = defaultCols
+	}
+	if rows <= 0 {
+		rows = defaultRows
+	}
+
+	commandLine := "cmd.exe /c " + w.program
+	opts := []conpty.ConPtyOption{
+		conpty.ConPtyDimensions(cols, rows),
+	}
+	if workDir != "" {
+		opts = append(opts, conpty.ConPtyWorkDir(workDir))
+	}
+
+	cpty, err := conpty.Start(commandLine, opts...)
+	if err != nil {
+		w.mu.Unlock()
+		return fmt.Errorf("start conpty: %w", err)
+	}
+
+	w.cpty = cpty
+	w.isRunning = true
+	w.outputDone = make(chan struct{})
+	w.mu.Unlock()
+
+	go w.readOutput()
+	w.handleTrustScreen()
+	return nil
+}
+
+// readOutput continuously reads from the ConPTY and appends to the screen buffer.
+// When attached, it also tees output to os.Stdout.
+func (w *WindowsTerminalSession) readOutput() {
+	defer close(w.outputDone)
+	buf := make([]byte, 4096)
+	for {
+		n, err := w.cpty.Read(buf)
+		if n > 0 {
+			data := buf[:n]
+			w.appendToBuffer(data)
+			if w.attached.Load() {
+				_, _ = os.Stdout.Write(data)
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// appendToBuffer parses raw terminal output into lines.
+func (w *WindowsTerminalSession) appendToBuffer(data []byte) {
+	w.bufMu.Lock()
+	defer w.bufMu.Unlock()
+
+	w.partial += string(data)
+	for {
+		idx := strings.IndexByte(w.partial, '\n')
+		if idx < 0 {
+			break
+		}
+		line := strings.TrimSuffix(w.partial[:idx], "\r")
+		w.lines = append(w.lines, line)
+		w.partial = w.partial[idx+1:]
+	}
+}
+
+// handleTrustScreen waits for the "trust files" prompt that claude/aider/gemini
+// show on first launch, and automatically confirms it.
+func (w *WindowsTerminalSession) handleTrustScreen() {
+	var searchString string
+	var tapFunc func() error
+	var maxWait time.Duration
+
+	if strings.HasSuffix(w.program, programClaude) {
+		searchString = "Do you trust the files in this folder?"
+		tapFunc = w.TapEnter
+		maxWait = 30 * time.Second
+	} else if strings.HasSuffix(w.program, programAider) || strings.HasSuffix(w.program, programGemini) {
+		searchString = "Open documentation url for more info"
+		tapFunc = func() error { return w.SendKeys("D\r") }
+		maxWait = 45 * time.Second
+	} else {
+		return
+	}
+
+	start := time.Now()
+	sleep := 100 * time.Millisecond
+	for time.Since(start) < maxWait {
+		time.Sleep(sleep)
+		content, err := w.CapturePaneContent()
+		if err == nil && strings.Contains(content, searchString) {
+			if err := tapFunc(); err != nil {
+				log.ErrorLog.Printf("could not tap enter on trust screen: %v", err)
+			}
+			return
+		}
+		sleep = time.Duration(float64(sleep) * 1.2)
+		if sleep > time.Second {
+			sleep = time.Second
+		}
+	}
+}
+
+// Restore checks if the process is still alive and updates the running state.
+func (w *WindowsTerminalSession) Restore() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.isRunning = w.doesSessionExistLocked()
+	return nil
+}
+
+func (w *WindowsTerminalSession) doesSessionExistLocked() bool {
+	if w.cpty == nil || w.outputDone == nil {
+		return false
+	}
+	select {
+	case <-w.outputDone:
+		return false // output reader finished → process exited
+	default:
+		return true
+	}
+}
+
+// DoesSessionExist checks if the ConPTY process is still alive.
+func (w *WindowsTerminalSession) DoesSessionExist() bool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.doesSessionExistLocked()
+}
+
+// SendKeys writes raw keystrokes to the ConPTY.
+func (w *WindowsTerminalSession) SendKeys(keys string) error {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	if !w.isRunning {
+		return fmt.Errorf("session not running")
+	}
+	_, err := w.cpty.Write([]byte(keys))
+	return err
+}
+
+// TapEnter sends a carriage return to the session.
+func (w *WindowsTerminalSession) TapEnter() error {
+	return w.SendKeys("\r")
+}
+
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+func stripANSI(s string) string {
+	return ansiRegex.ReplaceAllString(s, "")
+}
+
+// HasUpdated checks if output has changed and whether a prompt is visible.
+func (w *WindowsTerminalSession) HasUpdated() (updated bool, hasPrompt bool) {
+	content, err := w.CapturePaneContent()
+	if err != nil {
+		return false, false
+	}
+
+	plain := stripANSI(content)
+	if strings.HasSuffix(w.program, programClaude) {
+		hasPrompt = strings.Contains(plain, "No, and tell Claude what to do differently")
+	} else if strings.HasPrefix(w.program, programAider) {
+		hasPrompt = strings.Contains(plain, "(Y)es/(N)o/(D)on't ask again")
+	} else if strings.HasPrefix(w.program, programGemini) {
+		hasPrompt = strings.Contains(plain, "Yes, allow once")
+	}
+
+	h := sha256.Sum256([]byte(content))
+	hash := h[:]
+	if !bytes.Equal(hash, w.prevHash) {
+		w.prevHash = hash
+		return true, hasPrompt
+	}
+	return false, hasPrompt
+}
+
+// CapturePaneContent returns the last screenful of output (height lines).
+func (w *WindowsTerminalSession) CapturePaneContent() (string, error) {
+	w.bufMu.RLock()
+	defer w.bufMu.RUnlock()
+
+	h := w.height
+	if h <= 0 {
+		h = defaultRows
+	}
+
+	start := len(w.lines) - h
+	if start < 0 {
+		start = 0
+	}
+
+	var sb strings.Builder
+	for i, line := range w.lines[start:] {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(line)
+	}
+	if w.partial != "" {
+		if sb.Len() > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(w.partial)
+	}
+	return sb.String(), nil
+}
+
+// CapturePaneContentWithOptions returns all accumulated output (full history).
+func (w *WindowsTerminalSession) CapturePaneContentWithOptions(start, end string) (string, error) {
+	w.bufMu.RLock()
+	defer w.bufMu.RUnlock()
+
+	var sb strings.Builder
+	for i, line := range w.lines {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(line)
+	}
+	if w.partial != "" {
+		if sb.Len() > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(w.partial)
+	}
+	return sb.String(), nil
+}
+
+// SetDetachedSize updates the ConPTY dimensions while detached.
+func (w *WindowsTerminalSession) SetDetachedSize(width, height int) error {
+	w.mu.Lock()
+	w.width = width
+	w.height = height
+	w.mu.Unlock()
+
+	if w.cpty != nil {
+		return w.cpty.Resize(width, height)
+	}
+	return nil
+}
+
+// Attach connects stdin/stdout to the ConPTY for interactive use.
+// Returns a channel that is closed when the user detaches (Ctrl+Q).
+func (w *WindowsTerminalSession) Attach() (chan struct{}, error) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	if !w.isRunning {
+		return nil, fmt.Errorf("session not running")
+	}
+
+	w.attachCh = make(chan struct{})
+	w.ctx, w.cancel = context.WithCancel(context.Background())
+	w.wg = &sync.WaitGroup{}
+
+	// Show current content on attach so the user sees the current state.
+	content, _ := w.CapturePaneContent()
+	if content != "" {
+		fmt.Fprint(os.Stdout, content)
+	}
+	w.attached.Store(true)
+
+	// Stdin reader: forward keystrokes to ConPTY, detect Ctrl+Q to detach.
+	go func() {
+		timeout := time.After(50 * time.Millisecond)
+		buf := make([]byte, 256)
+		for {
+			nr, err := os.Stdin.Read(buf)
+			if err != nil {
+				if err == io.EOF {
+					return
+				}
+				continue
+			}
+
+			// Discard initial terminal control sequences.
+			select {
+			case <-timeout:
+			default:
+				log.InfoLog.Printf("nuked initial stdin: %q", buf[:nr])
+				continue
+			}
+
+			// Ctrl+Q (ASCII 17) → detach
+			if nr == 1 && buf[0] == 17 {
+				w.detach()
+				return
+			}
+
+			_, _ = w.cpty.Write(buf[:nr])
+		}
+	}()
+
+	// Window-size monitor (polling, since Windows has no SIGWINCH).
+	w.monitorWindowSize()
+
+	return w.attachCh, nil
+}
+
+// monitorWindowSize polls for terminal size changes and resizes the ConPTY.
+func (w *WindowsTerminalSession) monitorWindowSize() {
+	cols, rows, err := term.GetSize(int(os.Stdin.Fd()))
+	if err == nil {
+		_ = w.cpty.Resize(cols, rows)
+	}
+
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		ticker := time.NewTicker(250 * time.Millisecond)
+		defer ticker.Stop()
+
+		lastCols, lastRows := cols, rows
+		for {
+			select {
+			case <-w.ctx.Done():
+				return
+			case <-ticker.C:
+				c, r, err := term.GetSize(int(os.Stdin.Fd()))
+				if err != nil {
+					continue
+				}
+				if c != lastCols || r != lastRows {
+					lastCols, lastRows = c, r
+					_ = w.cpty.Resize(c, r)
+				}
+			}
+		}
+	}()
+}
+
+// detach disconnects stdin/stdout without stopping the background process.
+func (w *WindowsTerminalSession) detach() {
+	w.attached.Store(false)
+	if w.cancel != nil {
+		w.cancel()
+	}
+	if w.wg != nil {
+		w.wg.Wait()
+	}
+	if w.attachCh != nil {
+		close(w.attachCh)
+		w.attachCh = nil
+	}
+	w.cancel = nil
+	w.ctx = nil
+	w.wg = nil
+}
+
+// DetachSafely disconnects from the session without stopping the process.
+func (w *WindowsTerminalSession) DetachSafely() error {
+	if w.attachCh == nil {
+		return nil
+	}
+	w.detach()
+	return nil
+}
+
+// Close terminates the ConPTY process and cleans up resources.
+func (w *WindowsTerminalSession) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if !w.isRunning {
+		return nil
+	}
+
+	if w.cpty != nil {
+		if err := w.cpty.Close(); err != nil {
+			w.isRunning = false
+			return err
+		}
+	}
+
+	// Wait for output reader to finish.
+	if w.outputDone != nil {
+		<-w.outputDone
+	}
+
+	w.isRunning = false
+	return nil
+}
+
+// CleanupSessions is a no-op on Windows. ConPTY sessions are tied to their
+// process lifetime and do not need global enumeration like tmux.
+func CleanupSessions(cmdExec cmd.Executor) error {
+	return nil
+}

--- a/session/winterminal/winterminal_test.go
+++ b/session/winterminal/winterminal_test.go
@@ -1,0 +1,333 @@
+//go:build windows
+
+package winterminal
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+
+	"claude-squad/cmd/cmd_test"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Unit tests (no ConPTY needed) ---
+
+func TestSanitizeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "simple name", input: "test", expected: "claudesquad_test"},
+		{name: "name with spaces", input: "my session", expected: "claudesquad_my_session"},
+		{name: "name with hyphens", input: "my-session", expected: "claudesquad_my_session"},
+		{name: "name with dots", input: "my.session", expected: "claudesquad_my_session"},
+		{name: "name with mixed special chars", input: "my session-name.v2", expected: "claudesquad_my_session_name_v2"},
+		{name: "empty name", input: "", expected: "claudesquad_"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, sanitizeName(tc.input))
+		})
+	}
+}
+
+func TestNewWindowsTerminalSession(t *testing.T) {
+	session := NewWindowsTerminalSession("test-session", "claude")
+	assert.Equal(t, "test-session", session.sessionName)
+	assert.Equal(t, "claudesquad_test_session", session.sanitizedName)
+	assert.Equal(t, "claude", session.program)
+	assert.False(t, session.isRunning)
+	assert.Nil(t, session.cpty)
+	assert.NotNil(t, session.cmdExec)
+}
+
+func TestNewWindowsTerminalSessionWithDeps(t *testing.T) {
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte(""), nil },
+	}
+	session := NewWindowsTerminalSessionWithDeps("test-session", "claude", cmdExec)
+	assert.Equal(t, "test-session", session.sessionName)
+	assert.Equal(t, "claudesquad_test_session", session.sanitizedName)
+	assert.Equal(t, "claude", session.program)
+	assert.False(t, session.isRunning)
+}
+
+func TestDoesSessionExist_NoCpty(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	assert.False(t, session.DoesSessionExist())
+}
+
+func TestClose_NotRunning(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	err := session.Close()
+	assert.NoError(t, err)
+	assert.False(t, session.isRunning)
+}
+
+func TestSendKeys_NotRunning(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	err := session.SendKeys("hello")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not running")
+}
+
+func TestTapEnter_NotRunning(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	err := session.TapEnter()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not running")
+}
+
+func TestAttach_NotRunning(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	ch, err := session.Attach()
+	assert.Error(t, err)
+	assert.Nil(t, ch)
+	assert.Contains(t, err.Error(), "not running")
+}
+
+func TestCapturePaneContent_Empty(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	content, err := session.CapturePaneContent()
+	assert.NoError(t, err)
+	assert.Equal(t, "", content)
+}
+
+func TestCapturePaneContentWithOptions_Empty(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	content, err := session.CapturePaneContentWithOptions("-", "-")
+	assert.NoError(t, err)
+	assert.Equal(t, "", content)
+}
+
+func TestSetDetachedSize_NoCpty(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	err := session.SetDetachedSize(80, 24)
+	assert.NoError(t, err)
+	assert.Equal(t, 80, session.width)
+	assert.Equal(t, 24, session.height)
+}
+
+func TestDetachSafely_NotAttached(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	err := session.DetachSafely()
+	assert.NoError(t, err)
+}
+
+func TestRestore_NotExisting(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	err := session.Restore()
+	assert.NoError(t, err)
+	assert.False(t, session.isRunning)
+}
+
+func TestStart_AlreadyRunning(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	session.isRunning = true
+	err := session.Start(t.TempDir())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "already running")
+}
+
+func TestCleanupSessions(t *testing.T) {
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc:    func(cmd *exec.Cmd) error { return nil },
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) { return []byte(""), nil },
+	}
+	err := CleanupSessions(cmdExec)
+	assert.NoError(t, err)
+}
+
+func TestStripANSI(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "no ansi", input: "hello world", expected: "hello world"},
+		{name: "color codes", input: "\x1b[31mred\x1b[0m", expected: "red"},
+		{name: "bold", input: "\x1b[1mbold\x1b[0m text", expected: "bold text"},
+		{name: "empty", input: "", expected: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, stripANSI(tc.input))
+		})
+	}
+}
+
+func TestAppendToBuffer(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+
+	// Single line with newline
+	session.appendToBuffer([]byte("hello\n"))
+	assert.Equal(t, []string{"hello"}, session.lines)
+	assert.Equal(t, "", session.partial)
+
+	// Partial line
+	session.appendToBuffer([]byte("world"))
+	assert.Equal(t, []string{"hello"}, session.lines)
+	assert.Equal(t, "world", session.partial)
+
+	// Complete the partial line
+	session.appendToBuffer([]byte("!\n"))
+	assert.Equal(t, []string{"hello", "world!"}, session.lines)
+	assert.Equal(t, "", session.partial)
+
+	// CRLF handling
+	session.appendToBuffer([]byte("line\r\n"))
+	assert.Equal(t, []string{"hello", "world!", "line"}, session.lines)
+
+	// Multiple lines at once
+	session.appendToBuffer([]byte("a\nb\nc\n"))
+	assert.Equal(t, 6, len(session.lines))
+}
+
+func TestCapturePaneContent_WithBuffer(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	session.height = 3
+
+	for i := 0; i < 10; i++ {
+		session.appendToBuffer([]byte("line\n"))
+	}
+
+	content, err := session.CapturePaneContent()
+	assert.NoError(t, err)
+	// Should return last 3 lines
+	assert.Equal(t, "line\nline\nline", content)
+}
+
+func TestCapturePaneContentWithOptions_WithBuffer(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+	session.height = 3
+
+	session.appendToBuffer([]byte("first\nsecond\nthird\n"))
+
+	content, err := session.CapturePaneContentWithOptions("-", "-")
+	assert.NoError(t, err)
+	// Full history returns everything
+	assert.Equal(t, "first\nsecond\nthird", content)
+}
+
+func TestHasUpdated_EmptyThenSame(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+
+	// First call on empty buffer — content differs from nil hash
+	updated, hasPrompt := session.HasUpdated()
+	assert.True(t, updated)
+	assert.False(t, hasPrompt)
+
+	// Second call with same empty content — no change
+	updated, hasPrompt = session.HasUpdated()
+	assert.False(t, updated)
+	assert.False(t, hasPrompt)
+}
+
+func TestHasUpdated_ContentChange(t *testing.T) {
+	session := NewWindowsTerminalSession("test", "claude")
+
+	// Seed initial hash
+	session.HasUpdated()
+
+	// Add content → should detect update
+	session.appendToBuffer([]byte("new output\n"))
+	updated, _ := session.HasUpdated()
+	assert.True(t, updated)
+
+	// Same content → no update
+	updated, _ = session.HasUpdated()
+	assert.False(t, updated)
+}
+
+func TestHasUpdated_PromptDetection(t *testing.T) {
+	tests := []struct {
+		program string
+		prompt  string
+	}{
+		{"claude", "No, and tell Claude what to do differently"},
+		{"aider", "(Y)es/(N)o/(D)on't ask again"},
+		{"gemini", "Yes, allow once"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.program, func(t *testing.T) {
+			session := NewWindowsTerminalSession("test", tc.program)
+			session.appendToBuffer([]byte(tc.prompt + "\n"))
+			_, hasPrompt := session.HasUpdated()
+			assert.True(t, hasPrompt)
+		})
+	}
+}
+
+// --- Integration tests (require real ConPTY on Windows) ---
+
+func TestStart_EchoCommand(t *testing.T) {
+	session := NewWindowsTerminalSession("test-echo", "echo hello world")
+	err := session.Start(t.TempDir())
+	require.NoError(t, err)
+	defer session.Close()
+
+	// Wait for output to be captured
+	time.Sleep(1 * time.Second)
+
+	assert.True(t, session.isRunning || !session.isRunning) // process may have exited
+
+	content, err := session.CapturePaneContent()
+	assert.NoError(t, err)
+	assert.Contains(t, content, "hello world")
+}
+
+func TestStart_SessionAlive(t *testing.T) {
+	// Use "cmd.exe" directly (stays running until we close)
+	session := NewWindowsTerminalSession("test-alive", "cmd.exe /k echo ready")
+	err := session.Start(t.TempDir())
+	require.NoError(t, err)
+	defer session.Close()
+
+	time.Sleep(500 * time.Millisecond)
+
+	assert.True(t, session.DoesSessionExist())
+
+	err = session.Close()
+	assert.NoError(t, err)
+
+	// After close, session should not exist
+	time.Sleep(200 * time.Millisecond)
+	assert.False(t, session.DoesSessionExist())
+}
+
+func TestSendKeys_Running(t *testing.T) {
+	session := NewWindowsTerminalSession("test-keys", "cmd.exe /k echo ready")
+	err := session.Start(t.TempDir())
+	require.NoError(t, err)
+	defer session.Close()
+
+	time.Sleep(500 * time.Millisecond)
+
+	err = session.SendKeys("echo from-sendkeys\r")
+	assert.NoError(t, err)
+
+	time.Sleep(500 * time.Millisecond)
+
+	content, err := session.CapturePaneContent()
+	assert.NoError(t, err)
+	assert.Contains(t, content, "from-sendkeys")
+}
+
+func TestSetDetachedSize_Running(t *testing.T) {
+	session := NewWindowsTerminalSession("test-resize", "cmd.exe /k echo ready")
+	err := session.Start(t.TempDir())
+	require.NoError(t, err)
+	defer session.Close()
+
+	time.Sleep(500 * time.Millisecond)
+
+	err = session.SetDetachedSize(120, 40)
+	assert.NoError(t, err)
+	assert.Equal(t, 120, session.width)
+	assert.Equal(t, 40, session.height)
+}

--- a/test.bat
+++ b/test.bat
@@ -1,0 +1,25 @@
+@echo off
+setlocal
+
+cd /d "%~dp0"
+
+:: Find Go on PATH or in standard install locations
+where go >nul 2>&1
+if %errorlevel% equ 0 (
+    set "GO=go"
+) else if exist "C:\Program Files\Go\bin\go.exe" (
+    set "GO=C:\Program Files\Go\bin\go.exe"
+) else (
+    echo Error: Go is not installed or not in PATH.
+    echo Install from https://go.dev/dl/
+    exit /b 1
+)
+
+echo Running tests...
+"%GO%" test ./... -timeout 120s %*
+if %errorlevel% neq 0 (
+    echo Tests failed.
+    exit /b 1
+)
+
+echo All tests passed.

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")"
+
+echo "Running tests..."
+go test ./... -timeout 120s "$@"
+
+echo "All tests passed."

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -62,7 +62,7 @@ func setupTestEnvironment(t *testing.T, cmdExec cmd_test.MockCmdExec) *testSetup
 
 	// Set up tmux session with mocks
 	tmuxSession := tmux.NewTmuxSessionWithDeps(sessionName, "bash", ptyFactory, cmdExec)
-	instance.SetTmuxSession(tmuxSession)
+	instance.SetTerminalSession(tmuxSession)
 
 	// Start the tmux session
 	err = instance.Start(true)

--- a/ui/preview_test.go
+++ b/ui/preview_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package ui
 
 import (


### PR DESCRIPTION
Add windows support by refactoring out terminal into an interface, and then giving windows its own version.

Add tests for new interfaces and close coverage gaps introduced by the changes. All tests pass,

<img width="1084" height="1080" alt="image" src="https://github.com/user-attachments/assets/8342bf75-84a4-47b1-80fd-84d131999a40" />
