### PR TITLE
fix: make TUI subprocess calls async to resolve UI freezing (#215)

### DIFF
--- a/session/instance.go
+++ b/session/instance.go
@@ -506,6 +506,11 @@ func (i *Instance) UpdateDiffStats() error {
 	return nil
 }
 
+// SetDiffStats sets the diff stats (used by the async metadata update path).
+func (i *Instance) SetDiffStats(stats *git.DiffStats) {
+	i.diffStats = stats
+}
+
 // GetDiffStats returns the current git diff statistics
 func (i *Instance) GetDiffStats() *git.DiffStats {
 	return i.diffStats

--- a/ui/preview.go
+++ b/ui/preview.go
@@ -112,6 +112,18 @@ func (p *PreviewPane) UpdateContent(instance *session.Instance) error {
 	return nil
 }
 
+// SetPreviewContent sets the preview pane content directly from pre-captured
+// content, avoiding a redundant subprocess call. Used by the async preview path.
+func (p *PreviewPane) SetPreviewContent(content string) {
+	if p.isScrolling {
+		return
+	}
+	p.previewState = previewState{
+		fallback: false,
+		text:     content,
+	}
+}
+
 // Returns the preview pane content as a string.
 func (p *PreviewPane) String() string {
 	if p.width == 0 || p.height == 0 {

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -116,6 +116,15 @@ func (w *TabbedWindow) UpdatePreview(instance *session.Instance) error {
 	return w.preview.UpdateContent(instance)
 }
 
+// SetPreviewContent sets pre-captured content directly on the preview pane,
+// bypassing the subprocess call. Used by the async preview path.
+func (w *TabbedWindow) SetPreviewContent(content string) {
+	if w.activeTab != PreviewTab {
+		return
+	}
+	w.preview.SetPreviewContent(content)
+}
+
 func (w *TabbedWindow) UpdateDiff(instance *session.Instance) {
 	if w.activeTab != DiffTab {
 		return


### PR DESCRIPTION
## Summary
- **Metadata polling** (`tmux capture-pane`, `git diff`): moved from synchronous `Update()` to async `tea.Cmd` pattern — UI blocking drops from 100ms+ to µs per tick
- **Preview capture** (`tmux capture-pane`): same async pattern applied — no longer freezes UI while capturing pane content
- **Trust screen detection**: polling loop moved from blocking `Start()` to a background goroutine — session creation returns immediately

Fixes #215

## Problem
The bubbletea `Update()` handler was calling subprocess commands synchronously. Every metadata tick blocked the entire UI for 100-500ms depending on disk speed. With multiple sessions, this scaled linearly (e.g., 8 sessions × 200ms = 1.6s of UI freeze per tick cycle). Even with a single session, keystrokes were noticeably delayed.

## Approach
Converted blocking subprocess calls into the standard bubbletea async pattern:
1. `Update()` captures state and returns a `tea.Cmd` closure (returns in µs)
2. The closure runs subprocess calls in a bubbletea-managed goroutine
3. Results come back as a new message type, applied on the main event loop

Thread safety is maintained because:
- Goroutines only perform stateless subprocess calls (read-only)
- All mutable state writes happen exclusively on the main event loop thread
- Next tick is scheduled only after the result message is processed (no concurrent goroutine overlap)

## Changed files
| File | Change |
|---|---|
| `app/app.go` | Async metadata tick + async preview tick handlers |
| `session/instance.go` | Added `SetDiffStats()` for async result application |
| `session/tmux/tmux.go` | Trust screen polling moved to goroutine |
| `ui/preview.go` | Added `SetPreviewContent()` for async preview |
| `ui/tabbed_window.go` | Added `SetPreviewContent()` delegation |

## Benchmark results (before → after)
(you can check benchmark code here, https://github.com/CUN-bjy/claude-squad/tree/fix/tui-performance-215-with-tests)
| Scenario | OLD (sync) | NEW (async) | Speedup |
|---|---|---|---|
| Metadata tick (1 session, typical) | 107ms | 4µs | 26,000x |
| Preview tick (1 session, typical) | 50ms | 5µs | 9,000x |
| Metadata tick (8 sessions, slow disk) | 1.66s | 4µs | 414,000x |
| End-to-end keystroke responsiveness | 323ms blocked | 6µs blocked | 53,000x |

*Note: Total work time is unchanged — subprocesses still run in the background. The improvement is in UI blocking time (how long keystrokes are delayed).*

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Race detector clean (`go test -race ./...`)
- [x] Before/after benchmark comparison tests added
- [x] Trust screen async goroutine verification tests added
- [x] Manual testing: confirmed TUI is responsive with real sessions

If you find my work helpful, fuel the next commit with a coffee ☕
  <a href="https://paypal.me/JunyeobBaek"><img src="https://img.shields.io/badge/Buy%20Me%20A%20Coffee-FFDD00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black" height="35"></a>

🤖 Generated with [Claude Code](https://claude.com/claude-code)