### PR TITLE
feat: project-scoped session filtering

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -10,6 +10,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -21,9 +23,9 @@ import (
 const GlobalInstanceLimit = 10
 
 // Run is the main entrypoint into the application.
-func Run(ctx context.Context, program string, autoYes bool) error {
+func Run(ctx context.Context, program string, autoYes bool, repoRoot string, showAll bool) error {
 	p := tea.NewProgram(
-		newHome(ctx, program, autoYes),
+		newHome(ctx, program, autoYes, repoRoot, showAll),
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(), // Mouse scroll
 	)
@@ -60,6 +62,14 @@ type home struct {
 	// appState stores persistent application state like seen help screens
 	appState config.AppState
 
+	// repoRoot is the git repo root for the current working directory
+	repoRoot string
+	// showAll disables project-scoped filtering when true
+	showAll bool
+	// otherProjectData holds raw InstanceData for sessions not matching the current project,
+	// so they can be preserved when saving back to disk
+	otherProjectData []session.InstanceData
+
 	// -- State --
 
 	// state is the current discrete state of the application
@@ -94,7 +104,20 @@ type home struct {
 	confirmationOverlay *overlay.ConfirmationOverlay
 }
 
-func newHome(ctx context.Context, program string, autoYes bool) *home {
+// instanceMatchesRepo returns true if the given InstanceData belongs to the given repo root.
+func instanceMatchesRepo(data session.InstanceData, repoRoot string) bool {
+	// Check worktree repo path first (primary match)
+	if data.Worktree.RepoPath != "" {
+		return data.Worktree.RepoPath == repoRoot
+	}
+	// Fall back to checking if the session path starts with the repo root (older sessions)
+	if data.Path != "" {
+		return strings.HasPrefix(data.Path, repoRoot)
+	}
+	return false
+}
+
+func newHome(ctx context.Context, program string, autoYes bool, repoRoot string, showAll bool) *home {
 	// Load application config
 	appConfig := config.LoadConfig()
 
@@ -106,6 +129,12 @@ func newHome(ctx context.Context, program string, autoYes bool) *home {
 	if err != nil {
 		fmt.Printf("Failed to initialize storage: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Determine the repo name for the list header
+	var repoName string
+	if repoRoot != "" && !showAll {
+		repoName = filepath.Base(repoRoot)
 	}
 
 	h := &home{
@@ -120,18 +149,35 @@ func newHome(ctx context.Context, program string, autoYes bool) *home {
 		autoYes:      autoYes,
 		state:        stateDefault,
 		appState:     appState,
+		repoRoot:     repoRoot,
+		showAll:      showAll,
 	}
-	h.list = ui.NewList(&h.spinner, autoYes)
+	h.list = ui.NewList(&h.spinner, autoYes, repoName)
 
-	// Load saved instances
-	instances, err := storage.LoadInstances()
+	// Load raw instance data for filtering
+	allData, err := storage.LoadInstanceData()
 	if err != nil {
 		fmt.Printf("Failed to load instances: %v\n", err)
 		os.Exit(1)
 	}
 
-	// Add loaded instances to the list
-	for _, instance := range instances {
+	// Partition into matching and non-matching instances
+	var matchingData []session.InstanceData
+	for _, data := range allData {
+		if showAll || repoRoot == "" || instanceMatchesRepo(data, repoRoot) {
+			matchingData = append(matchingData, data)
+		} else {
+			h.otherProjectData = append(h.otherProjectData, data)
+		}
+	}
+
+	// Hydrate only matching instances
+	for _, data := range matchingData {
+		instance, err := session.FromInstanceData(data)
+		if err != nil {
+			fmt.Printf("Failed to create instance %s: %v\n", data.Title, err)
+			os.Exit(1)
+		}
 		// Call the finalizer immediately.
 		h.list.AddInstance(instance)()
 		if autoYes {
@@ -260,7 +306,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Save after successful start
-		if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
+		if err := m.storage.SaveInstancesWithExtra(m.list.GetInstances(), m.otherProjectData); err != nil {
 			return m, m.handleError(err)
 		}
 		if m.autoYes {
@@ -286,7 +332,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *home) handleQuit() (tea.Model, tea.Cmd) {
-	if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
+	if err := m.storage.SaveInstancesWithExtra(m.list.GetInstances(), m.otherProjectData); err != nil {
 		return m, m.handleError(err)
 	}
 	return m, tea.Quit

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -109,7 +109,7 @@ func TestConfirmationModalStateTransitions(t *testing.T) {
 func TestConfirmationModalKeyHandling(t *testing.T) {
 	// Import needed packages
 	spinner := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	list := ui.NewList(&spinner, false)
+	list := ui.NewList(&spinner, false, "")
 
 	// Create enough of home struct to test handleKeyPress in confirmation state
 	h := &home{
@@ -230,7 +230,7 @@ func TestConfirmationMessageFormatting(t *testing.T) {
 func TestConfirmationFlowSimulation(t *testing.T) {
 	// Create a minimal setup
 	spinner := spinner.New(spinner.WithSpinner(spinner.MiniDot))
-	list := ui.NewList(&spinner, false)
+	list := ui.NewList(&spinner, false, "")
 
 	// Add test instance
 	instance, err := session.NewInstance(session.InstanceOptions{

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	programFlag string
 	autoYesFlag bool
 	daemonFlag  bool
+	allFlag     bool
 	rootCmd     = &cobra.Command{
 		Use:   "claude-squad",
 		Short: "Claude Squad - Manage multiple AI agents like Claude Code, Aider, Codex, and Amp.",
@@ -45,6 +46,11 @@ var (
 
 			if !git.IsGitRepo(currentDir) {
 				return fmt.Errorf("error: claude-squad must be run from within a git repository")
+			}
+
+			repoRoot, err := git.FindGitRepoRoot(currentDir)
+			if err != nil {
+				return fmt.Errorf("failed to find git repo root: %w", err)
 			}
 
 			cfg := config.LoadConfig()
@@ -71,7 +77,7 @@ var (
 				log.ErrorLog.Printf("failed to stop daemon: %v", err)
 			}
 
-			return app.Run(ctx, program, autoYes)
+			return app.Run(ctx, program, autoYes, repoRoot, allFlag)
 		},
 	}
 
@@ -150,6 +156,7 @@ func init() {
 		"[experimental] If enabled, all instances will automatically accept prompts")
 	rootCmd.Flags().BoolVar(&daemonFlag, "daemon", false, "Run a program that loads all sessions"+
 		" and runs autoyes mode on them.")
+	rootCmd.Flags().BoolVarP(&allFlag, "all", "a", false, "Show sessions from all projects")
 
 	// Hide the daemonFlag as it's only for internal use
 	err := rootCmd.Flags().MarkHidden("daemon")

--- a/session/git/util.go
+++ b/session/git/util.go
@@ -54,7 +54,7 @@ func IsGitRepo(path string) bool {
 	return cmd.Run() == nil
 }
 
-func findGitRepoRoot(path string) (string, error) {
+func FindGitRepoRoot(path string) (string, error) {
 	cmd := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel")
 	out, err := cmd.Output()
 	if err != nil {

--- a/session/git/worktree.go
+++ b/session/git/worktree.go
@@ -57,7 +57,7 @@ func NewGitWorktree(repoPath string, sessionName string) (tree *GitWorktree, bra
 		absPath = repoPath
 	}
 
-	repoPath, err = findGitRepoRoot(absPath)
+	repoPath, err = FindGitRepoRoot(absPath)
 	if err != nil {
 		return nil, "", err
 	}

--- a/session/storage.go
+++ b/session/storage.go
@@ -92,6 +92,39 @@ func (s *Storage) LoadInstances() ([]*Instance, error) {
 	return instances, nil
 }
 
+// LoadInstanceData loads the raw instance data without hydrating into full Instances.
+// This avoids tmux side effects for sessions that will be filtered out.
+func (s *Storage) LoadInstanceData() ([]InstanceData, error) {
+	jsonData := s.state.GetInstances()
+
+	var instancesData []InstanceData
+	if err := json.Unmarshal(jsonData, &instancesData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal instances: %w", err)
+	}
+
+	return instancesData, nil
+}
+
+// SaveInstancesWithExtra saves the hydrated instances plus extra raw InstanceData
+// (from other projects) back to disk, preserving sessions that were filtered out.
+func (s *Storage) SaveInstancesWithExtra(instances []*Instance, extra []InstanceData) error {
+	data := make([]InstanceData, 0)
+	for _, instance := range instances {
+		if instance.Started() {
+			data = append(data, instance.ToInstanceData())
+		}
+	}
+
+	data = append(data, extra...)
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal instances: %w", err)
+	}
+
+	return s.state.SaveInstances(jsonData)
+}
+
 // DeleteInstance removes an instance from storage
 func (s *Storage) DeleteInstance(title string) error {
 	instances, err := s.LoadInstances()

--- a/ui/list.go
+++ b/ui/list.go
@@ -59,18 +59,21 @@ type List struct {
 	height, width int
 	renderer      *InstanceRenderer
 	autoyes       bool
+	// repoName is displayed in the list header when set (project-scoped filtering)
+	repoName string
 
 	// map of repo name to number of instances using it. Used to display the repo name only if there are
 	// multiple repos in play.
 	repos map[string]int
 }
 
-func NewList(spinner *spinner.Model, autoYes bool) *List {
+func NewList(spinner *spinner.Model, autoYes bool, repoName string) *List {
 	return &List{
 		items:    []*session.Instance{},
 		renderer: &InstanceRenderer{spinner: spinner},
 		repos:    make(map[string]int),
 		autoyes:  autoYes,
+		repoName: repoName,
 	}
 }
 
@@ -226,7 +229,10 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 }
 
 func (l *List) String() string {
-	const titleText = " Instances "
+	titleText := " Instances "
+	if l.repoName != "" {
+		titleText = " " + l.repoName + " "
+	}
 	const autoYesText = " auto-yes "
 
 	// Write the title.


### PR DESCRIPTION
When working across multiple projects, it is easy to mix up which agent instances belong to which project. This PR addresses this issue by scoping the list of instances to the current project. The original behavior is still available with an `--all` flag.

## Summary
- Filter sessions by the current git repo so only relevant sessions are shown when running `cs` from a project directory
- Add `--all` / `-a` flag to bypass filtering and see all sessions
- Display the project name in the list header when filtering is active
- Non-matching sessions are preserved in storage and merged back on save — nothing is lost

## Implementation
- Export `FindGitRepoRoot` from `session/git` and resolve repo root in `main.go`
- Add `LoadInstanceData()` and `SaveInstancesWithExtra()` to storage for data-level partitioning
- Filter sessions in `app.go` by matching `Worktree.RepoPath` against the current repo root, with a fallback to `Path` prefix matching for older sessions
- Only hydrate (connect to tmux) sessions that match the current project

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./...` passes
- [ ] Run `cs` in repo A, create a session, quit. Run `cs` in repo B — repo A's session should not appear
- [ ] Run `cs --all` — all sessions from all projects should be visible
- [ ] Return to repo A — session is still there
- [ ] Kill a session while filtering is active — other project sessions remain in storage