### PR TITLE
fix: wait for CLI readiness before SendPrompt to prevent prompt loss

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -287,15 +287,24 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.menu.SetState(ui.StatePrompt)
 			m.textInputOverlay = m.newPromptOverlay()
 		} else {
-			// If instance has a prompt (set from Shift+N flow), send it now
+			// If instance has a prompt (set from Shift+N flow), wait for CLI
+			// readiness before sending to avoid the prompt being lost.
+			cmds := []tea.Cmd{tea.WindowSize(), m.instanceChanged()}
 			if msg.instance.Prompt != "" {
-				if err := msg.instance.SendPrompt(msg.instance.Prompt); err != nil {
-					log.ErrorLog.Printf("failed to send prompt: %v", err)
-				}
+				prompt := msg.instance.Prompt
 				msg.instance.Prompt = ""
+				instance := msg.instance
+				cmds = append(cmds, func() tea.Msg {
+					instance.WaitForCliReady(30 * time.Second)
+					if err := instance.SendPrompt(prompt); err != nil {
+						log.ErrorLog.Printf("failed to send prompt: %v", err)
+					}
+					return nil
+				})
 			}
 			m.menu.SetState(ui.StateDefault)
 			m.showHelpScreen(helpStart(msg.instance), nil)
+			return m, tea.Batch(cmds...)
 		}
 
 		return m, tea.Batch(tea.WindowSize(), m.instanceChanged())

--- a/session/instance.go
+++ b/session/instance.go
@@ -555,6 +555,14 @@ func (i *Instance) GetDiffStats() *git.DiffStats {
 	return i.diffStats
 }
 
+// WaitForCliReady waits for the CLI in the tmux session to be ready for input.
+func (i *Instance) WaitForCliReady(timeout time.Duration) bool {
+	if !i.started || i.tmuxSession == nil {
+		return false
+	}
+	return i.tmuxSession.WaitForCliReady(timeout)
+}
+
 // SendPrompt sends a prompt to the tmux session
 func (i *Instance) SendPrompt(prompt string) error {
 	if !i.started {

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -23,6 +23,7 @@ const ProgramClaude = "claude"
 
 const ProgramAider = "aider"
 const ProgramGemini = "gemini"
+const ProgramCodex = "codex"
 
 // TmuxSession represents a managed tmux session
 type TmuxSession struct {
@@ -177,6 +178,77 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 		}
 	}
 	return false
+}
+
+// IsCliReady checks if the CLI program in the tmux session has finished
+// initializing and is ready to accept user input.
+func (t *TmuxSession) IsCliReady() bool {
+	content, err := t.CapturePaneContent()
+	if err != nil {
+		return false
+	}
+
+	trimmed := strings.TrimRight(content, " \t\n\r")
+	if trimmed == "" {
+		return false
+	}
+
+	switch {
+	case strings.HasSuffix(t.program, ProgramClaude):
+		// Claude shows ❯ prompt or /help text when ready
+		return strings.Contains(content, "❯") || strings.Contains(content, "/help")
+	case strings.HasPrefix(t.program, ProgramAider):
+		return strings.HasSuffix(trimmed, ">")
+	case strings.HasPrefix(t.program, ProgramGemini):
+		return strings.HasSuffix(trimmed, ">")
+	case strings.HasPrefix(t.program, ProgramCodex):
+		return strings.HasSuffix(trimmed, ">")
+	default:
+		// Unknown CLI: no specific check, rely on stability fallback in WaitForCliReady
+		return false
+	}
+}
+
+// WaitForCliReady polls until the CLI is ready for input or the timeout expires.
+// It first checks known CLI prompt patterns via IsCliReady, then falls back to
+// content stability detection for unknown CLIs.
+// Returns true if the CLI became ready, false on timeout.
+func (t *TmuxSession) WaitForCliReady(timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	const interval = 200 * time.Millisecond
+	var prevContent string
+	stableCount := 0
+	const stableThreshold = 5 // 5 * 200ms = 1s of stable content
+
+	for {
+		select {
+		case <-deadline:
+			log.InfoLog.Printf("WaitForCliReady: timed out after %v for %s", timeout, t.program)
+			return false
+		default:
+		}
+
+		if t.IsCliReady() {
+			return true
+		}
+
+		// Fallback: detect content stability (content not changing)
+		content, err := t.CapturePaneContent()
+		if err == nil && content != "" && content == prevContent {
+			stableCount++
+			if stableCount >= stableThreshold {
+				log.InfoLog.Printf("WaitForCliReady: content stable for %s, assuming ready", t.program)
+				return true
+			}
+		} else {
+			stableCount = 0
+			if err == nil {
+				prevContent = content
+			}
+		}
+
+		time.Sleep(interval)
+	}
 }
 
 // Restore attaches to an existing session and restores the window size


### PR DESCRIPTION
## Summary

- Fix timing race condition where `SendPrompt()` sends text before CLI (Claude, Aider, Codex, etc.) finishes initialization, causing the prompt to be lost when using Shift+N to create an instance with a prompt
- Add `IsCliReady()` / `WaitForCliReady()` methods to detect CLI input-ready state by checking program-specific prompt patterns (❯ for Claude, > for Aider/Gemini/Codex) with content-stability fallback for unknown CLIs
- Change the `instanceStartedMsg` handler to send the prompt asynchronously via `tea.Cmd`, so the UI remains responsive during the wait

## Test plan

- [ ] Create instance via Shift+N with prompt using Codex CLI — confirm prompt is delivered
- [ ] Create instance via Shift+N with prompt using Claude CLI — confirm prompt is delivered
- [ ] Create instance via Shift+N without prompt — confirm no regression
- [ ] Create instance via regular N flow — confirm no regression
- [ ] Verify UI does not freeze while waiting for CLI readiness

Fixes #266