### PR TITLE
feat: add worktree setup hook for post-creation environment setup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,12 @@ type Config struct {
 	BranchPrefix string `json:"branch_prefix"`
 	// Profiles is a list of named program profiles.
 	Profiles []Profile `json:"profiles,omitempty"`
+	// WorktreeSetupHook is a command to run after worktree creation.
+	// Environment variables available: CS_REPO_PATH, CS_WORKTREE_PATH, CS_BRANCH, CS_SESSION
+	WorktreeSetupHook string `json:"worktree_setup_hook"`
+	// WorktreeSetupHookFailMode controls behavior on hook failure.
+	// "continue" (default) - log error and continue, "fail" - abort session creation
+	WorktreeSetupHookFailMode string `json:"worktree_setup_hook_fail_mode"`
 }
 
 // GetProgram returns the program to run. If Profiles is non-empty and

--- a/session/hooks/hooks.go
+++ b/session/hooks/hooks.go
@@ -1,0 +1,66 @@
+package hooks
+
+import (
+	"claude-squad/log"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// WorktreeContext contains information passed to worktree setup hooks
+type WorktreeContext struct {
+	RepoPath     string
+	WorktreePath string
+	BranchName   string
+	SessionName  string
+}
+
+// RunWorktreeSetupHook executes the configured setup hook after worktree creation.
+// Returns nil if no hook is configured or if hook succeeds.
+// Returns error only if failMode is "fail" and hook fails.
+func RunWorktreeSetupHook(hookCmd string, failMode string, ctx WorktreeContext) error {
+	if hookCmd == "" {
+		return nil
+	}
+
+	log.InfoLog.Printf("Running worktree setup hook: %s", hookCmd)
+
+	// Parse command - support both simple commands and shell expressions
+	var cmd *exec.Cmd
+	if strings.Contains(hookCmd, " ") {
+		// Use shell to handle complex commands
+		cmd = exec.Command("sh", "-c", hookCmd)
+	} else {
+		cmd = exec.Command(hookCmd)
+	}
+
+	// Set working directory to the new worktree
+	cmd.Dir = ctx.WorktreePath
+
+	// Set environment variables for hook context
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("CS_REPO_PATH=%s", ctx.RepoPath),
+		fmt.Sprintf("CS_WORKTREE_PATH=%s", ctx.WorktreePath),
+		fmt.Sprintf("CS_BRANCH=%s", ctx.BranchName),
+		fmt.Sprintf("CS_SESSION=%s", ctx.SessionName),
+	)
+
+	// Capture output for logging
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.ErrorLog.Printf("Worktree setup hook failed: %v\nOutput: %s", err, string(output))
+
+		if failMode == "fail" {
+			return fmt.Errorf("worktree setup hook failed: %w", err)
+		}
+		// Default: log and continue
+		return nil
+	}
+
+	if len(output) > 0 {
+		log.InfoLog.Printf("Worktree setup hook output:\n%s", string(output))
+	}
+
+	return nil
+}

--- a/session/hooks/hooks_test.go
+++ b/session/hooks/hooks_test.go
@@ -1,0 +1,114 @@
+package hooks
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunWorktreeSetupHook_NoHook(t *testing.T) {
+	ctx := WorktreeContext{
+		RepoPath:     "/tmp/repo",
+		WorktreePath: "/tmp/worktree",
+		BranchName:   "test-branch",
+		SessionName:  "test-session",
+	}
+
+	err := RunWorktreeSetupHook("", "continue", ctx)
+	if err != nil {
+		t.Errorf("Expected nil error for empty hook, got: %v", err)
+	}
+}
+
+func TestRunWorktreeSetupHook_SimpleCommand(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "hooks-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ctx := WorktreeContext{
+		RepoPath:     tmpDir,
+		WorktreePath: tmpDir,
+		BranchName:   "test-branch",
+		SessionName:  "test-session",
+	}
+
+	err = RunWorktreeSetupHook("echo hello", "continue", ctx)
+	if err != nil {
+		t.Errorf("Expected nil error for successful hook, got: %v", err)
+	}
+}
+
+func TestRunWorktreeSetupHook_EnvironmentVariables(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "hooks-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	markerFile := filepath.Join(tmpDir, "env-check.txt")
+	hookCmd := "echo $CS_REPO_PATH $CS_WORKTREE_PATH $CS_BRANCH $CS_SESSION > " + markerFile
+
+	ctx := WorktreeContext{
+		RepoPath:     "/path/to/repo",
+		WorktreePath: tmpDir,
+		BranchName:   "my-branch",
+		SessionName:  "my-session",
+	}
+
+	err = RunWorktreeSetupHook(hookCmd, "continue", ctx)
+	if err != nil {
+		t.Errorf("Expected nil error, got: %v", err)
+	}
+
+	content, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("Failed to read marker file: %v", err)
+	}
+
+	expected := "/path/to/repo " + tmpDir + " my-branch my-session\n"
+	if string(content) != expected {
+		t.Errorf("Expected env vars %q, got %q", expected, string(content))
+	}
+}
+
+func TestRunWorktreeSetupHook_FailModeContinue(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "hooks-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ctx := WorktreeContext{
+		RepoPath:     tmpDir,
+		WorktreePath: tmpDir,
+		BranchName:   "test-branch",
+		SessionName:  "test-session",
+	}
+
+	err = RunWorktreeSetupHook("exit 1", "continue", ctx)
+	if err != nil {
+		t.Errorf("Expected nil error in continue mode, got: %v", err)
+	}
+}
+
+func TestRunWorktreeSetupHook_FailModeFail(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "hooks-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ctx := WorktreeContext{
+		RepoPath:     tmpDir,
+		WorktreePath: tmpDir,
+		BranchName:   "test-branch",
+		SessionName:  "test-session",
+	}
+
+	err = RunWorktreeSetupHook("exit 1", "fail", ctx)
+	if err == nil {
+		t.Error("Expected error in fail mode, got nil")
+	}
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -1,8 +1,10 @@
 package session
 
 import (
+	"claude-squad/config"
 	"claude-squad/log"
 	"claude-squad/session/git"
+	"claude-squad/session/hooks"
 	"claude-squad/session/tmux"
 	"path/filepath"
 
@@ -255,6 +257,29 @@ func (i *Instance) Start(firstTimeSetup bool) error {
 		if err := i.gitWorktree.Setup(); err != nil {
 			setupErr = fmt.Errorf("failed to setup git worktree: %w", err)
 			return setupErr
+		}
+
+		// Run worktree setup hook if configured
+		cfg := config.LoadConfig()
+		if cfg.WorktreeSetupHook != "" {
+			hookCtx := hooks.WorktreeContext{
+				RepoPath:     i.Path,
+				WorktreePath: i.gitWorktree.GetWorktreePath(),
+				BranchName:   i.Branch,
+				SessionName:  i.Title,
+			}
+			if err := hooks.RunWorktreeSetupHook(
+				cfg.WorktreeSetupHook,
+				cfg.WorktreeSetupHookFailMode,
+				hookCtx,
+			); err != nil {
+				// Only reaches here if fail_mode is "fail"
+				if cleanupErr := i.gitWorktree.Cleanup(); cleanupErr != nil {
+					err = fmt.Errorf("%v (cleanup error: %v)", err, cleanupErr)
+				}
+				setupErr = fmt.Errorf("worktree setup hook failed: %w", err)
+				return setupErr
+			}
 		}
 
 		// Create new session


### PR DESCRIPTION
## Summary
- Adds `worktree_setup_hook` config option that runs a user-defined command after worktree creation
- Passes worktree context via environment variables (`CS_REPO_PATH`, `CS_WORKTREE_PATH`, `CS_BRANCH`, `CS_SESSION`)
- Configurable failure mode: `continue` (default, log and proceed) or `fail` (abort session creation)

Closes #260

## Example config
```json
{
  "worktree_setup_hook": "npm install && cp ../.env .env",
  "worktree_setup_hook_fail_mode": "continue"
}
```

## Test plan
- [x] Unit tests for hook execution (5 test cases covering no-hook, success, env vars, continue mode, fail mode)
- [ ] Manual testing with `workz sync --isolated` as hook command
- [ ] Manual testing with custom shell script as hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)