### PR TITLE
feat: worktree setup hook (#260)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -22,9 +22,9 @@ import (
 const GlobalInstanceLimit = 10
 
 // Run is the main entrypoint into the application.
-func Run(ctx context.Context, program string, autoYes bool) error {
+func Run(ctx context.Context, program string, autoYes bool, setupHook string) error {
 	p := tea.NewProgram(
-		newHome(ctx, program, autoYes),
+		newHome(ctx, program, autoYes, setupHook),
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(), // Mouse scroll
 	)
@@ -51,8 +51,9 @@ type home struct {
 
 	// -- Storage and Configuration --
 
-	program string
-	autoYes bool
+	program   string
+	autoYes   bool
+	setupHook string
 
 	// storage is the interface for saving/loading data to/from the app's state
 	storage *session.Storage
@@ -95,7 +96,7 @@ type home struct {
 	confirmationOverlay *overlay.ConfirmationOverlay
 }
 
-func newHome(ctx context.Context, program string, autoYes bool) *home {
+func newHome(ctx context.Context, program string, autoYes bool, setupHook string) *home {
 	// Load application config
 	appConfig := config.LoadConfig()
 
@@ -119,6 +120,7 @@ func newHome(ctx context.Context, program string, autoYes bool) *home {
 		appConfig:    appConfig,
 		program:      program,
 		autoYes:      autoYes,
+		setupHook:    setupHook,
 		state:        stateDefault,
 		appState:     appState,
 	}
@@ -587,9 +589,10 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		}
 
 		instance, err := session.NewInstance(session.InstanceOptions{
-			Title:   "",
-			Path:    ".",
-			Program: m.program,
+			Title:     "",
+			Path:      ".",
+			Program:   m.program,
+			SetupHook: m.setupHook,
 		})
 		if err != nil {
 			return m, m.handleError(err)
@@ -608,9 +611,10 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 				fmt.Errorf("you can't create more than %d instances", GlobalInstanceLimit))
 		}
 		instance, err := session.NewInstance(session.InstanceOptions{
-			Title:   "",
-			Path:    ".",
-			Program: m.program,
+			Title:     "",
+			Path:      ".",
+			Program:   m.program,
+			SetupHook: m.setupHook,
 		})
 		if err != nil {
 			return m, m.handleError(err)

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,10 @@ type Config struct {
 	BranchPrefix string `json:"branch_prefix"`
 	// Profiles is a list of named program profiles.
 	Profiles []Profile `json:"profiles,omitempty"`
+	// WorktreeSetup is a shell command run in the new worktree after it is created.
+	// Use this to install dependencies, copy env files, or run any other setup.
+	// Example: "workz sync --isolated"  or  "npm install && cp ../.env .env"
+	WorktreeSetup string `json:"worktree_setup,omitempty"`
 }
 
 // GetProgram returns the program to run. If Profiles is non-empty and

--- a/main.go
+++ b/main.go
@@ -18,11 +18,12 @@ import (
 )
 
 var (
-	version     = "1.0.17"
-	programFlag string
-	autoYesFlag bool
-	daemonFlag  bool
-	rootCmd     = &cobra.Command{
+	version       = "1.0.17"
+	programFlag   string
+	autoYesFlag   bool
+	daemonFlag    bool
+	setupHookFlag string
+	rootCmd       = &cobra.Command{
 		Use:   "claude-squad",
 		Short: "Claude Squad - Manage multiple AI agents like Claude Code, Aider, Codex, and Amp.",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -59,6 +60,11 @@ var (
 			if autoYesFlag {
 				autoYes = true
 			}
+			// SetupHook: CLI flag overrides config
+			setupHook := cfg.WorktreeSetup
+			if setupHookFlag != "" {
+				setupHook = setupHookFlag
+			}
 			if autoYes {
 				defer func() {
 					if err := daemon.LaunchDaemon(); err != nil {
@@ -71,7 +77,7 @@ var (
 				log.ErrorLog.Printf("failed to stop daemon: %v", err)
 			}
 
-			return app.Run(ctx, program, autoYes)
+			return app.Run(ctx, program, autoYes, setupHook)
 		},
 	}
 
@@ -150,6 +156,9 @@ func init() {
 		"[experimental] If enabled, all instances will automatically accept prompts")
 	rootCmd.Flags().BoolVar(&daemonFlag, "daemon", false, "Run a program that loads all sessions"+
 		" and runs autoyes mode on them.")
+	rootCmd.Flags().StringVar(&setupHookFlag, "setup", "",
+		"Shell command to run inside each new worktree after creation (overrides worktree_setup in config). "+
+			"Example: --setup \"workz sync --isolated\"")
 
 	// Hide the daemonFlag as it's only for internal use
 	err := rootCmd.Flags().MarkHidden("daemon")

--- a/session/instance.go
+++ b/session/instance.go
@@ -4,6 +4,7 @@ import (
 	"claude-squad/log"
 	"claude-squad/session/git"
 	"claude-squad/session/tmux"
+	"os/exec"
 	"path/filepath"
 
 	"fmt"
@@ -51,6 +52,8 @@ type Instance struct {
 	AutoYes bool
 	// Prompt is the initial prompt to pass to the instance on startup
 	Prompt string
+	// SetupHook is an optional shell command run inside the worktree after it is created.
+	SetupHook string
 
 	// DiffStats stores the current git diff statistics
 	diffStats *git.DiffStats
@@ -157,6 +160,9 @@ type InstanceOptions struct {
 	AutoYes bool
 	// Branch is an existing branch name to start the session on (empty = new branch from HEAD)
 	Branch string
+	// SetupHook is an optional shell command run inside the new worktree after it is created.
+	// Runs via $SHELL -c "...". An error aborts the session creation.
+	SetupHook string
 }
 
 func NewInstance(opts InstanceOptions) (*Instance, error) {
@@ -179,7 +185,28 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 		UpdatedAt:      t,
 		AutoYes:        false,
 		selectedBranch: opts.Branch,
+		SetupHook:      opts.SetupHook,
 	}, nil
+}
+
+// runSetupHook executes i.SetupHook in the worktree directory via the user's shell.
+func (i *Instance) runSetupHook() error {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+
+	worktreePath := i.gitWorktree.GetWorktreePath()
+	log.InfoLog.Printf("running worktree setup hook in %s: %s", worktreePath, i.SetupHook)
+
+	cmd := exec.Command(shell, "-c", i.SetupHook)
+	cmd.Dir = worktreePath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("command %q exited with error: %w\noutput:\n%s", i.SetupHook, err, output)
+	}
+	log.InfoLog.Printf("setup hook output:\n%s", output)
+	return nil
 }
 
 func (i *Instance) RepoName() (string, error) {
@@ -255,6 +282,14 @@ func (i *Instance) Start(firstTimeSetup bool) error {
 		if err := i.gitWorktree.Setup(); err != nil {
 			setupErr = fmt.Errorf("failed to setup git worktree: %w", err)
 			return setupErr
+		}
+
+		// Run optional setup hook inside the new worktree
+		if i.SetupHook != "" {
+			if err := i.runSetupHook(); err != nil {
+				setupErr = fmt.Errorf("worktree setup hook failed: %w", err)
+				return setupErr
+			}
 		}
 
 		// Create new session


### PR DESCRIPTION
## Summary

Resolves #260.

When Claude Squad creates a new worktree, users currently face three environment problems:
- **Missing env files** — `.env`, `.envrc`, etc. are gitignored and not copied
- **Missing dependencies** — `node_modules`, `.venv`, `target/` need reinstalling per worktree
- **Port / Docker Compose conflicts** — multiple sessions bind the same port or share the same compose namespace

This PR adds a **worktree setup hook**: a shell command that runs inside the newly created worktree directory right after `git worktree add` completes. Users can plug in [workz](https://github.com/rohansx/workz), a custom script, or any one-liner.

## Changes

### `config/config.go`
- Added `WorktreeSetup string` field (JSON: `worktree_setup`) to `Config`

### `session/instance.go`  
- Added `SetupHook string` to `Instance` and `InstanceOptions`
- After `gitWorktree.Setup()` succeeds, `runSetupHook()` executes the command via `$SHELL -c "..."` in the worktree directory
- Hook failure aborts session creation and triggers the existing cleanup path

### `main.go`
- Added `--setup` CLI flag; overrides the config value per-invocation

### `app/app.go`
- `Run` / `newHome` now accept and store `setupHook`; passed to every `NewInstance` call

## Usage

**One-off via flag:**
```bash
claude-squad --setup "workz sync --isolated"
claude-squad --setup "npm install && cp ../.env .env"
```

**Persistent via config** (`~/.claude-squad/config.json`):
```json
{
  "worktree_setup": "workz sync --isolated"
}
```

The CLI flag always wins over the config value, so you can override per-project.

## Test plan
- [ ] `go build ./...` — clean build ✅
- [ ] `go test ./...` — all existing tests pass ✅
- [ ] Manual: run `claude-squad --setup "echo hello > setup.txt"`, verify `setup.txt` appears in the worktree
- [ ] Manual: run with a failing hook (`--setup "exit 1"`), verify session creation is aborted and no dangling worktree is left
- [ ] Manual: set `worktree_setup` in config, create a session without `--setup`, verify hook runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)