### PR TITLE
feat: add `cs recover` command to restore dead tmux sessions

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,6 +133,120 @@ var (
 		},
 	}
 
+	recoverCmd = &cobra.Command{
+		Use:   "recover",
+		Short: "Recover instances with dead tmux sessions",
+		Long: `Recover instances whose tmux sessions died (e.g. after a system restart)
+but whose git worktrees are still intact. For Claude programs, sessions are
+restarted with --resume to pick up the previous conversation.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			log.Initialize(false)
+			defer log.Close()
+
+			state := config.LoadState()
+			storage, err := session.NewStorage(state)
+			if err != nil {
+				return fmt.Errorf("failed to initialize storage: %w", err)
+			}
+
+			instancesData, err := storage.LoadInstancesRaw()
+			if err != nil {
+				return fmt.Errorf("failed to load instances: %w", err)
+			}
+
+			if len(instancesData) == 0 {
+				fmt.Println("No instances found.")
+				return nil
+			}
+
+			// Find recoverable instances
+			var recoverable []session.InstanceData
+			var alive []session.InstanceData
+			var dead []session.InstanceData
+
+			for _, data := range instancesData {
+				if data.Status == session.Paused {
+					continue
+				}
+				if session.IsRecoverable(data) {
+					recoverable = append(recoverable, data)
+				} else {
+					ts := tmux.NewTmuxSession(data.Title, data.Program)
+					if ts.DoesSessionExist() {
+						alive = append(alive, data)
+					} else {
+						dead = append(dead, data)
+					}
+				}
+			}
+
+			if len(alive) > 0 {
+				fmt.Printf("Alive (%d):\n", len(alive))
+				for _, d := range alive {
+					fmt.Printf("  ✓ %s [%s]\n", d.Title, d.Branch)
+				}
+			}
+
+			if len(dead) > 0 {
+				fmt.Printf("Dead (worktree missing, cannot recover) (%d):\n", len(dead))
+				for _, d := range dead {
+					fmt.Printf("  ✗ %s [%s]\n", d.Title, d.Branch)
+				}
+			}
+
+			if len(recoverable) == 0 {
+				fmt.Println("\nNo recoverable instances found.")
+				return nil
+			}
+
+			fmt.Printf("\nRecoverable (%d):\n", len(recoverable))
+			for _, d := range recoverable {
+				fmt.Printf("  ↻ %s [%s] %s\n", d.Title, d.Branch, d.Worktree.WorktreePath)
+			}
+
+			// Recover all instances
+			fmt.Printf("\nRecovering %d instance(s)...\n", len(recoverable))
+
+			// First, load all instances that are still alive (including paused)
+			var allInstances []*session.Instance
+			for _, data := range instancesData {
+				isRecoverable := false
+				for _, r := range recoverable {
+					if r.Title == data.Title {
+						isRecoverable = true
+						break
+					}
+				}
+
+				if isRecoverable {
+					instance, err := session.RecoverInstance(data)
+					if err != nil {
+						fmt.Printf("  ✗ Failed to recover %s: %v\n", data.Title, err)
+						continue
+					}
+					allInstances = append(allInstances, instance)
+					fmt.Printf("  ✓ Recovered %s\n", data.Title)
+				} else {
+					// For alive/paused instances, load normally but handle errors gracefully
+					instance, err := session.FromInstanceData(data)
+					if err != nil {
+						fmt.Printf("  ⚠ Skipping %s (load error: %v)\n", data.Title, err)
+						continue
+					}
+					allInstances = append(allInstances, instance)
+				}
+			}
+
+			// Save updated state
+			if err := storage.SaveInstances(allInstances); err != nil {
+				return fmt.Errorf("failed to save instances: %w", err)
+			}
+
+			fmt.Println("\nRecovery complete. Run 'cs' to manage your instances.")
+			return nil
+		},
+	}
+
 	versionCmd = &cobra.Command{
 		Use:   "version",
 		Short: "Print the version number of claude-squad",
@@ -160,6 +274,7 @@ func init() {
 	rootCmd.AddCommand(debugCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(resetCmd)
+	rootCmd.AddCommand(recoverCmd)
 }
 
 func main() {

--- a/session/instance.go
+++ b/session/instance.go
@@ -145,6 +145,70 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 	return instance, nil
 }
 
+// RecoverInstance creates an Instance from saved data and starts a new tmux session
+// without requiring the old tmux session to be alive. For Claude programs, it appends
+// --resume to pick up the previous conversation.
+func RecoverInstance(data InstanceData) (*Instance, error) {
+	instance := &Instance{
+		Title:     data.Title,
+		Path:      data.Path,
+		Branch:    data.Branch,
+		Status:    data.Status,
+		Height:    data.Height,
+		Width:     data.Width,
+		CreatedAt: data.CreatedAt,
+		UpdatedAt: data.UpdatedAt,
+		Program:   data.Program,
+		gitWorktree: git.NewGitWorktreeFromStorage(
+			data.Worktree.RepoPath,
+			data.Worktree.WorktreePath,
+			data.Worktree.SessionName,
+			data.Worktree.BranchName,
+			data.Worktree.BaseCommitSHA,
+			data.Worktree.IsExistingBranch,
+		),
+		diffStats: &git.DiffStats{
+			Added:   data.DiffStats.Added,
+			Removed: data.DiffStats.Removed,
+			Content: data.DiffStats.Content,
+		},
+	}
+
+	// For Claude, append --resume to pick up the previous conversation
+	program := data.Program
+	if strings.HasSuffix(program, tmux.ProgramClaude) && !strings.Contains(program, "--resume") {
+		program = program + " --resume"
+	}
+	instance.tmuxSession = tmux.NewTmuxSession(instance.Title, program)
+
+	// Start a new tmux session in the existing worktree directory
+	worktreePath := data.Worktree.WorktreePath
+	if err := instance.tmuxSession.Start(worktreePath); err != nil {
+		return nil, fmt.Errorf("failed to start tmux session: %w", err)
+	}
+
+	instance.started = true
+	instance.SetStatus(Running)
+
+	return instance, nil
+}
+
+// IsRecoverable checks if an instance can be recovered: worktree exists but tmux is dead.
+func IsRecoverable(data InstanceData) bool {
+	// Check if worktree directory exists
+	if _, err := os.Stat(data.Worktree.WorktreePath); os.IsNotExist(err) {
+		return false
+	}
+
+	// Check if tmux session is dead
+	ts := tmux.NewTmuxSession(data.Title, data.Program)
+	if ts.DoesSessionExist() {
+		return false // tmux is alive, no recovery needed
+	}
+
+	return true
+}
+
 // Options for creating a new instance
 type InstanceOptions struct {
 	// Title is the title of the instance.

--- a/session/storage.go
+++ b/session/storage.go
@@ -72,6 +72,19 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 	return s.state.SaveInstances(jsonData)
 }
 
+// LoadInstancesRaw loads instance data without starting them.
+// This is useful for inspecting instances before attempting to restore tmux sessions.
+func (s *Storage) LoadInstancesRaw() ([]InstanceData, error) {
+	jsonData := s.state.GetInstances()
+
+	var instancesData []InstanceData
+	if err := json.Unmarshal(jsonData, &instancesData); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal instances: %w", err)
+	}
+
+	return instancesData, nil
+}
+
 // LoadInstances loads the list of instances from disk
 func (s *Storage) LoadInstances() ([]*Instance, error) {
 	jsonData := s.state.GetInstances()


### PR DESCRIPTION
## Summary

- Adds `cs recover` subcommand that detects and restores instances whose tmux sessions died (e.g. after system restart, WSL2 reboot, or crash) while git worktrees remain intact
- For Claude programs, automatically appends `--resume` flag to pick up previous conversations
- Categorizes instances into Alive / Recoverable / Dead for clear status reporting

## Problem

When tmux sessions die unexpectedly, `cs` crashes on startup because `FromInstanceData()` calls `tmuxSession.Restore()` which fails on non-existent sessions. Users lose access to all their instances and have to manually recreate them.

## Solution

`cs recover` loads instance data without starting tmux sessions (`LoadInstancesRaw`), checks which instances have intact worktrees but dead tmux sessions (`IsRecoverable`), and restarts them with new tmux sessions (`RecoverInstance`).

### Files changed
- `main.go` — `cs recover` cobra command
- `session/instance.go` — `RecoverInstance()`, `IsRecoverable()` 
- `session/storage.go` — `LoadInstancesRaw()` 

### Usage
```bash
cs recover
```

### Example output
```
Recoverable (3):
  ↻ trainer [yoon/trainer] /home/user/.claude-squad/worktrees/...
  ↻ evaluator [yoon/evaluator] /home/user/.claude-squad/worktrees/...
  ↻ backend [yoon/backend] /home/user/.claude-squad/worktrees/...

Recovering 3 instance(s)...
  ✓ Recovered trainer
  ✓ Recovered evaluator
  ✓ Recovered backend

Recovery complete. Run 'cs' to manage your instances.
```

## Test plan

- [x] Build passes (`go build`)
- [x] `go vet ./...` clean
- [x] Tested with 10 dead instances after WSL2 restart — all recovered successfully
- [x] Verified `claude --resume` picks up previous conversations
- [x] Verified recovered sessions appear correctly in `cs` TUI after recovery
- [x] Existing tests pass