### PR TITLE
perf: compute full diff only for the selected instance

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -189,7 +189,7 @@ func (m *home) Init() tea.Cmd {
 			time.Sleep(100 * time.Millisecond)
 			return previewTickMsg{}
 		},
-		tickUpdateMetadataCmd(m.snapshotActiveInstances()),
+		tickUpdateMetadataCmd(m.snapshotActiveInstances(), m.list.GetSelectedInstance()),
 	)
 }
 
@@ -253,7 +253,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				r.instance.SetDiffStats(r.diffStats)
 			}
 		}
-		return m, tickUpdateMetadataCmd(m.snapshotActiveInstances())
+		return m, tickUpdateMetadataCmd(m.snapshotActiveInstances(), m.list.GetSelectedInstance())
 	case tea.MouseMsg:
 		// Handle mouse wheel events for scrolling the diff/preview pane
 		if msg.Action == tea.MouseActionPress {
@@ -927,7 +927,11 @@ func (m *home) snapshotActiveInstances() []*session.Instance {
 // Because it only re-schedules after completing, overlapping ticks are impossible.
 // The active instances slice should be snapshotted on the main thread via
 // snapshotActiveInstances() before being passed here.
-func tickUpdateMetadataCmd(active []*session.Instance) tea.Cmd {
+//
+// Only the selected instance gets a full diff (with Content); the rest get a
+// lightweight numstat-only summary. This keeps per-instance memory bounded
+// since the diff pane only ever renders the selected one.
+func tickUpdateMetadataCmd(active []*session.Instance, selected *session.Instance) tea.Cmd {
 	return func() tea.Msg {
 		time.Sleep(500 * time.Millisecond)
 
@@ -944,7 +948,11 @@ func tickUpdateMetadataCmd(active []*session.Instance) tea.Cmd {
 				r := &results[i]
 				r.instance = instance
 				r.updated, r.hasPrompt = instance.HasUpdated()
-				r.diffStats = instance.ComputeDiff()
+				if instance == selected {
+					r.diffStats = instance.ComputeDiff()
+				} else {
+					r.diffStats = instance.ComputeDiffNumstat()
+				}
 			}(idx, inst)
 		}
 		wg.Wait()

--- a/session/git/diff.go
+++ b/session/git/diff.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"strconv"
 	"strings"
 )
 
@@ -46,6 +47,47 @@ func (g *GitWorktree) Diff() *DiffStats {
 		}
 	}
 	stats.Content = content
+
+	return stats
+}
+
+// DiffNumstat returns the added/removed line counts between the worktree and the
+// base branch without loading the full diff content into memory. Use this when
+// only the summary counts are needed (e.g. for unselected instances in the list).
+func (g *GitWorktree) DiffNumstat() *DiffStats {
+	stats := &DiffStats{}
+
+	// -N stages untracked files (intent to add), including them in the diff
+	_, err := g.runGitCommand(g.worktreePath, "add", "-N", ".")
+	if err != nil {
+		stats.Error = err
+		return stats
+	}
+
+	out, err := g.runGitCommand(g.worktreePath, "--no-pager", "diff", "--numstat", g.GetBaseCommitSHA())
+	if err != nil {
+		stats.Error = err
+		return stats
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		if line == "" {
+			continue
+		}
+		// Each line is: <added>\t<removed>\t<path>. Binary files report "-\t-\t<path>"
+		// and are skipped for the line-count totals.
+		fields := strings.SplitN(line, "\t", 3)
+		if len(fields) < 2 {
+			continue
+		}
+		added, aerr := strconv.Atoi(fields[0])
+		removed, rerr := strconv.Atoi(fields[1])
+		if aerr != nil || rerr != nil {
+			continue
+		}
+		stats.Added += added
+		stats.Removed += removed
+	}
 
 	return stats
 }

--- a/session/git/diff.go
+++ b/session/git/diff.go
@@ -70,24 +70,29 @@ func (g *GitWorktree) DiffNumstat() *DiffStats {
 		return stats
 	}
 
+	stats.Added, stats.Removed = parseNumstat(out)
+	return stats
+}
+
+// parseNumstat sums the added/removed columns from `git diff --numstat` output.
+// Each line is formatted as <added>\t<removed>\t<path>. Binary files report
+// "-\t-\t<path>" and are ignored for line totals.
+func parseNumstat(out string) (added int, removed int) {
 	for _, line := range strings.Split(out, "\n") {
 		if line == "" {
 			continue
 		}
-		// Each line is: <added>\t<removed>\t<path>. Binary files report "-\t-\t<path>"
-		// and are skipped for the line-count totals.
 		fields := strings.SplitN(line, "\t", 3)
 		if len(fields) < 2 {
 			continue
 		}
-		added, aerr := strconv.Atoi(fields[0])
-		removed, rerr := strconv.Atoi(fields[1])
+		a, aerr := strconv.Atoi(fields[0])
+		r, rerr := strconv.Atoi(fields[1])
 		if aerr != nil || rerr != nil {
 			continue
 		}
-		stats.Added += added
-		stats.Removed += removed
+		added += a
+		removed += r
 	}
-
-	return stats
+	return added, removed
 }

--- a/session/git/diff_test.go
+++ b/session/git/diff_test.go
@@ -1,0 +1,59 @@
+package git
+
+import "testing"
+
+func TestParseNumstat(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantAdded   int
+		wantRemoved int
+	}{
+		{
+			name:        "empty output",
+			input:       "",
+			wantAdded:   0,
+			wantRemoved: 0,
+		},
+		{
+			name:        "single file",
+			input:       "3\t1\tfoo.go\n",
+			wantAdded:   3,
+			wantRemoved: 1,
+		},
+		{
+			name:        "multiple files sum correctly",
+			input:       "3\t1\tfoo.go\n10\t2\tbar/baz.go\n",
+			wantAdded:   13,
+			wantRemoved: 3,
+		},
+		{
+			name:        "binary files are skipped",
+			input:       "5\t0\tfoo.go\n-\t-\timage.png\n2\t2\tbar.go\n",
+			wantAdded:   7,
+			wantRemoved: 2,
+		},
+		{
+			name:        "path with tabs is preserved via SplitN",
+			input:       "4\t4\tpath\twith\ttabs.go\n",
+			wantAdded:   4,
+			wantRemoved: 4,
+		},
+		{
+			name:        "trailing newlines do not add garbage",
+			input:       "1\t0\ta.go\n\n\n",
+			wantAdded:   1,
+			wantRemoved: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAdded, gotRemoved := parseNumstat(tt.input)
+			if gotAdded != tt.wantAdded || gotRemoved != tt.wantRemoved {
+				t.Errorf("parseNumstat(%q) = (%d, %d), want (%d, %d)",
+					tt.input, gotAdded, gotRemoved, tt.wantAdded, tt.wantRemoved)
+			}
+		})
+	}
+}

--- a/session/instance.go
+++ b/session/instance.go
@@ -559,6 +559,17 @@ func (i *Instance) ComputeDiff() *git.DiffStats {
 	return i.gitWorktree.Diff()
 }
 
+// ComputeDiffNumstat runs a lightweight git diff --numstat and returns only the
+// added/removed line counts (Content is left empty). Safe to call from a
+// background goroutine. Use this for instances whose full diff content is not
+// currently needed so we avoid keeping large diffs in memory.
+func (i *Instance) ComputeDiffNumstat() *git.DiffStats {
+	if !i.started || i.Status == Paused {
+		return nil
+	}
+	return i.gitWorktree.DiffNumstat()
+}
+
 // SetDiffStats sets the diff statistics on the instance. Should be called from
 // the main event loop to avoid data races with View.
 func (i *Instance) SetDiffStats(stats *git.DiffStats) {


### PR DESCRIPTION
Closes #280

## Summary
The 500ms metadata tick in `tickUpdateMetadataCmd` calls `ComputeDiff()` for every active instance and stores each full diff string in `DiffStats.Content`, but the diff pane only ever renders one instance at a time. With N sessions this keeps N copies of full git diff output resident for zero UI benefit.

This PR keeps the full diff only for the currently-selected instance; every other instance gets a lightweight `git diff --numstat` summary that populates only `Added`/`Removed`. The list view's `+X/-Y` counters are unaffected because they only need the totals.

## Changes
- `session/git/diff.go`: add `DiffNumstat()` which runs `git diff --numstat <base>` and returns a `*DiffStats` with `Content` empty. Parsing is extracted into `parseNumstat` so it's unit-testable.
- `session/instance.go`: add `ComputeDiffNumstat()` mirroring `ComputeDiff()`.
- `app/app.go`: `tickUpdateMetadataCmd` now takes the selected instance and dispatches full-diff vs numstat accordingly. Both call sites pass `m.list.GetSelectedInstance()`.
- `session/git/diff_test.go`: unit tests for `parseNumstat` covering empty output, binary files (`-\t-`), multi-file sums, tabs-in-path, and trailing newlines.

## Trade-offs
Switching the selected instance incurs up to one tick (~500ms) before the diff pane repopulates with the full content — previously, the full diff was always resident for every instance so the switch felt instant. This is an intentional trade for bounded memory.

## Test plan
- [x] `go test ./...` passes locally
- [x] `gofmt -w .` clean
- [x] Manually verify the diff tab renders correctly for the selected instance
- [x] Manually verify preview / terminal tabs behave unchanged