### PR TITLE
feat: configurable max instances and session list scrolling

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -21,8 +21,6 @@ import (
 	"github.com/mattn/go-runewidth"
 )
 
-const GlobalInstanceLimit = 10
-
 // Run is the main entrypoint into the application.
 func Run(ctx context.Context, program string, autoYes bool) error {
 	p := tea.NewProgram(
@@ -606,9 +604,9 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 	case keys.KeyHelp:
 		return m.showHelpScreen(helpTypeGeneral{}, nil)
 	case keys.KeyPrompt:
-		if m.list.NumInstances() >= GlobalInstanceLimit {
+		if m.list.NumInstances() >= m.appConfig.MaxInstances {
 			return m, m.handleError(
-				fmt.Errorf("you can't create more than %d instances", GlobalInstanceLimit))
+				fmt.Errorf("you can't create more than %d instances", m.appConfig.MaxInstances))
 		}
 
 		// Start a background fetch so branches are up to date by the time the picker opens
@@ -635,9 +633,9 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 
 		return m, fetchCmd
 	case keys.KeyNew:
-		if m.list.NumInstances() >= GlobalInstanceLimit {
+		if m.list.NumInstances() >= m.appConfig.MaxInstances {
 			return m, m.handleError(
-				fmt.Errorf("you can't create more than %d instances", GlobalInstanceLimit))
+				fmt.Errorf("you can't create more than %d instances", m.appConfig.MaxInstances))
 		}
 		instance, err := session.NewInstance(session.InstanceOptions{
 			Title:   "",

--- a/config/config.go
+++ b/config/config.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	ConfigFileName = "config.json"
-	defaultProgram = "claude"
+	ConfigFileName      = "config.json"
+	defaultProgram      = "claude"
+	DefaultMaxInstances = 10
 )
 
 // GetConfigDir returns the path to the application's configuration directory
@@ -44,6 +45,8 @@ type Config struct {
 	BranchPrefix string `json:"branch_prefix"`
 	// Profiles is a list of named program profiles.
 	Profiles []Profile `json:"profiles,omitempty"`
+	// MaxInstances is the maximum number of instances that can be open at the same time.
+	MaxInstances int `json:"max_instances"`
 }
 
 // GetProgram returns the program to run. If Profiles is non-empty and
@@ -93,6 +96,7 @@ func DefaultConfig() *Config {
 		DefaultProgram:     program,
 		AutoYes:            false,
 		DaemonPollInterval: 1000,
+		MaxInstances:       DefaultMaxInstances,
 		BranchPrefix: func() string {
 			user, err := user.Current()
 			if err != nil || user == nil || user.Username == "" {
@@ -179,6 +183,10 @@ func LoadConfig() *Config {
 	if err := json.Unmarshal(data, &config); err != nil {
 		log.ErrorLog.Printf("failed to parse config file: %v", err)
 		return DefaultConfig()
+	}
+
+	if config.MaxInstances <= 0 {
+		config.MaxInstances = DefaultMaxInstances
 	}
 
 	return &config

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -106,6 +106,7 @@ func TestDefaultConfig(t *testing.T) {
 		assert.NotEmpty(t, config.DefaultProgram)
 		assert.False(t, config.AutoYes)
 		assert.Equal(t, 1000, config.DaemonPollInterval)
+		assert.Equal(t, DefaultMaxInstances, config.MaxInstances)
 		assert.NotEmpty(t, config.BranchPrefix)
 		assert.True(t, strings.HasSuffix(config.BranchPrefix, "/"))
 	})
@@ -172,6 +173,50 @@ func TestLoadConfig(t *testing.T) {
 		assert.True(t, config.AutoYes)
 		assert.Equal(t, 2000, config.DaemonPollInterval)
 		assert.Equal(t, "test/", config.BranchPrefix)
+	})
+
+	t.Run("defaults max_instances when not set in config file", func(t *testing.T) {
+		tempHome := t.TempDir()
+		configDir := filepath.Join(tempHome, ".claude-squad")
+		err := os.MkdirAll(configDir, 0755)
+		require.NoError(t, err)
+
+		configPath := filepath.Join(configDir, ConfigFileName)
+		configContent := `{
+			"default_program": "claude",
+			"auto_yes": false
+		}`
+		err = os.WriteFile(configPath, []byte(configContent), 0644)
+		require.NoError(t, err)
+
+		originalHome := os.Getenv("HOME")
+		os.Setenv("HOME", tempHome)
+		defer os.Setenv("HOME", originalHome)
+
+		config := LoadConfig()
+		assert.Equal(t, DefaultMaxInstances, config.MaxInstances)
+	})
+
+	t.Run("respects custom max_instances", func(t *testing.T) {
+		tempHome := t.TempDir()
+		configDir := filepath.Join(tempHome, ".claude-squad")
+		err := os.MkdirAll(configDir, 0755)
+		require.NoError(t, err)
+
+		configPath := filepath.Join(configDir, ConfigFileName)
+		configContent := `{
+			"default_program": "claude",
+			"max_instances": 25
+		}`
+		err = os.WriteFile(configPath, []byte(configContent), 0644)
+		require.NoError(t, err)
+
+		originalHome := os.Getenv("HOME")
+		os.Setenv("HOME", tempHome)
+		defer os.Setenv("HOME", originalHome)
+
+		config := LoadConfig()
+		assert.Equal(t, 25, config.MaxInstances)
 	})
 
 	t.Run("returns default config on invalid JSON", func(t *testing.T) {

--- a/ui/list.go
+++ b/ui/list.go
@@ -53,9 +53,15 @@ var autoYesStyle = lipgloss.NewStyle().
 	Background(lipgloss.Color("#dde4f0")).
 	Foreground(lipgloss.Color("#1a1a1a"))
 
+type listRenderedItem struct {
+	text  string
+	lines int
+}
+
 type List struct {
 	items         []*session.Instance
 	selectedIdx   int
+	scrollOffset  int
 	height, width int
 	renderer      *InstanceRenderer
 	autoyes       bool
@@ -252,14 +258,107 @@ func (l *List) String() string {
 	b.WriteString("\n")
 	b.WriteString("\n")
 
-	// Render the list.
+	// Header: 2 newlines + title line + 2 newlines = 4 lines consumed before items.
+	headerLines := 4
+
+	// Available lines for list items.
+	availableLines := l.height - headerLines
+	if availableLines < 1 {
+		availableLines = 1
+	}
+
+	// Render all items and measure their line heights (without separator).
+	rendered := make([]listRenderedItem, len(l.items))
 	for i, item := range l.items {
-		b.WriteString(l.renderer.Render(item, i+1, i == l.selectedIdx, len(l.repos) > 1))
-		if i != len(l.items)-1 {
+		text := l.renderer.Render(item, i+1, i == l.selectedIdx, len(l.repos) > 1)
+		lineCount := strings.Count(text, "\n") + 1
+		rendered[i] = listRenderedItem{text: text, lines: lineCount}
+	}
+	// Adjust scroll offset to keep the selected item visible.
+	l.adjustScrollOffset(rendered, availableLines)
+
+	// Render only items that fit within the viewport.
+	// Note: "\n\n" between items adds 2 newline chars but only 1 visible line,
+	// because the first \n terminates the previous item's last line.
+	linesUsed := 0
+	lastVisible := l.scrollOffset
+	for i := l.scrollOffset; i < len(rendered); i++ {
+		needed := rendered[i].lines
+		if i > l.scrollOffset {
+			needed += 1 // separator "\n\n" adds 1 empty line between items
+		}
+		if linesUsed+needed > availableLines && i > l.scrollOffset {
+			break
+		}
+		lastVisible = i
+		linesUsed += needed
+	}
+	for i := l.scrollOffset; i <= lastVisible; i++ {
+		b.WriteString(rendered[i].text)
+		if i != lastVisible {
 			b.WriteString("\n\n")
 		}
 	}
+
 	return lipgloss.Place(l.width, l.height, lipgloss.Left, lipgloss.Top, b.String())
+}
+
+// clampScrollOffset reduces the scroll offset so that the last item aligns
+// with the bottom of the viewport (no trailing empty space).
+func (l *List) clampScrollOffset() {
+	if l.scrollOffset <= 0 || len(l.items) == 0 {
+		return
+	}
+	// Each item is approximately 4 lines; separator adds 1 line between items.
+	// Use the same headerLines constant as String().
+	headerLines := 4
+	availableLines := l.height - headerLines
+	if availableLines < 1 {
+		return
+	}
+
+	for l.scrollOffset > 0 {
+		// Calculate total lines from scrollOffset to end.
+		linesUsed := 0
+		for i := l.scrollOffset; i < len(l.items); i++ {
+			lines := 4 // approximate item height
+			if i > l.scrollOffset {
+				lines += 1 // separator
+			}
+			linesUsed += lines
+		}
+		if linesUsed >= availableLines {
+			break
+		}
+		l.scrollOffset--
+	}
+}
+
+// adjustScrollOffset ensures the selected item is visible within the viewport.
+func (l *List) adjustScrollOffset(rendered []listRenderedItem, availableLines int) {
+	if len(rendered) == 0 {
+		return
+	}
+
+	// If selected is above the scroll offset, scroll up.
+	if l.selectedIdx < l.scrollOffset {
+		l.scrollOffset = l.selectedIdx
+		return
+	}
+
+	// If selected is below the visible area, scroll down.
+	linesUsed := 0
+	for i := l.scrollOffset; i <= l.selectedIdx && i < len(rendered); i++ {
+		needed := rendered[i].lines
+		if i > l.scrollOffset {
+			needed += 1 // separator adds 1 empty line
+		}
+		linesUsed += needed
+	}
+	for linesUsed > availableLines && l.scrollOffset < l.selectedIdx {
+		linesUsed -= rendered[l.scrollOffset].lines + 1 // remove item + its trailing separator
+		l.scrollOffset++
+	}
 }
 
 // Down selects the next item in the list.
@@ -299,6 +398,12 @@ func (l *List) Kill() {
 
 	// Since there's items after this, the selectedIdx can stay the same.
 	l.items = append(l.items[:l.selectedIdx], l.items[l.selectedIdx+1:]...)
+
+	// Adjust scroll offset so there's no empty space at the bottom after deletion.
+	if l.scrollOffset > 0 && l.scrollOffset >= len(l.items) {
+		l.scrollOffset = len(l.items) - 1
+	}
+	l.clampScrollOffset()
 }
 
 func (l *List) Attach() (chan struct{}, error) {

--- a/ui/list_test.go
+++ b/ui/list_test.go
@@ -1,0 +1,226 @@
+package ui
+
+import (
+	"claude-squad/log"
+	"claude-squad/session"
+	"os"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	log.Initialize(false)
+	defer log.Close()
+	os.Exit(m.Run())
+}
+
+// newTestList creates a list with n mock items and a given height.
+// Each item renders to 4 lines (title padding + title + desc + desc padding).
+func newTestList(n int, height int) *List {
+	s := spinner.New()
+	l := NewList(&s, false)
+	l.SetSize(60, height)
+
+	for i := 0; i < n; i++ {
+		inst := &session.Instance{Title: "test"}
+		l.items = append(l.items, inst)
+	}
+	return l
+}
+
+// visibleItemCount renders the list and counts how many items appear.
+func visibleItemCount(l *List) int {
+	rendered := renderItems(l)
+	if len(rendered) == 0 {
+		return 0
+	}
+
+	headerLines := 4
+	availableLines := l.height - headerLines
+	if availableLines < 1 {
+		return 0
+	}
+
+	count := 0
+	linesUsed := 0
+	for i := l.scrollOffset; i < len(rendered); i++ {
+		needed := rendered[i].lines
+		if i > l.scrollOffset {
+			needed += 1
+		}
+		if linesUsed+needed > availableLines && i > l.scrollOffset {
+			break
+		}
+		linesUsed += needed
+		count++
+	}
+	return count
+}
+
+// renderItems mirrors the rendering logic to get item line counts.
+func renderItems(l *List) []listRenderedItem {
+	rendered := make([]listRenderedItem, len(l.items))
+	for i, item := range l.items {
+		text := l.renderer.Render(item, i+1, i == l.selectedIdx, len(l.repos) > 1)
+		lineCount := len(splitLines(text))
+		rendered[i] = listRenderedItem{text: text, lines: lineCount}
+	}
+	return rendered
+}
+
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	lines := []string{}
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, s[start:i])
+			start = i + 1
+		}
+	}
+	lines = append(lines, s[start:])
+	return lines
+}
+
+func TestScrollDownAndUp(t *testing.T) {
+	// Height 30 should fit about 5 items (4 lines each + 1 separator).
+	l := newTestList(10, 30)
+
+	// Initially at top.
+	assert.Equal(t, 0, l.scrollOffset)
+	assert.Equal(t, 0, l.selectedIdx)
+
+	// Navigate down past visible area.
+	for i := 0; i < 9; i++ {
+		l.Down()
+	}
+	assert.Equal(t, 9, l.selectedIdx)
+
+	// Scroll offset should have moved to keep selection visible.
+	_ = l.String() // triggers adjustScrollOffset
+	assert.Greater(t, l.scrollOffset, 0, "scroll offset should increase when navigating down")
+
+	// Navigate back to top.
+	for i := 0; i < 9; i++ {
+		l.Up()
+	}
+	assert.Equal(t, 0, l.selectedIdx)
+	_ = l.String()
+	assert.Equal(t, 0, l.scrollOffset, "scroll offset should return to 0 when at top")
+}
+
+func TestScrollConsistentItemCount(t *testing.T) {
+	// Use enough items and height so scrolling is needed.
+	l := newTestList(20, 50)
+
+	// Scroll to bottom.
+	for i := 0; i < 19; i++ {
+		l.Down()
+	}
+	_ = l.String()
+	countAtBottom := visibleItemCount(l)
+
+	// Scroll back to top.
+	for i := 0; i < 19; i++ {
+		l.Up()
+	}
+	_ = l.String()
+	countAtTop := visibleItemCount(l)
+
+	assert.Equal(t, countAtTop, countAtBottom,
+		"visible item count should be the same at top and bottom")
+}
+
+func TestScrollAfterKillLastItem(t *testing.T) {
+	l := newTestList(15, 50)
+
+	// Scroll to the last item.
+	for i := 0; i < 14; i++ {
+		l.Down()
+	}
+	_ = l.String()
+	assert.Equal(t, 14, l.selectedIdx)
+	offsetBefore := l.scrollOffset
+
+	// Kill the last item — should not leave empty space at bottom.
+	// We can't call Kill() directly (it calls instance.Kill()), so simulate it.
+	l.items = append(l.items[:l.selectedIdx], l.items[l.selectedIdx+1:]...)
+	l.Up()
+	if l.scrollOffset >= len(l.items) {
+		l.scrollOffset = len(l.items) - 1
+	}
+	l.clampScrollOffset()
+
+	_ = l.String()
+	assert.Equal(t, 13, l.selectedIdx)
+	assert.LessOrEqual(t, l.scrollOffset, offsetBefore,
+		"scroll offset should decrease after deleting the last item")
+
+	// Verify no excessive empty space: visible items should reach the end of the list.
+	rendered := renderItems(l)
+	headerLines := 4
+	availableLines := l.height - headerLines
+	linesUsed := 0
+	lastVisible := l.scrollOffset
+	for i := l.scrollOffset; i < len(rendered); i++ {
+		needed := rendered[i].lines
+		if i > l.scrollOffset {
+			needed += 1
+		}
+		if linesUsed+needed > availableLines && i > l.scrollOffset {
+			break
+		}
+		lastVisible = i
+		linesUsed += needed
+	}
+	assert.Equal(t, len(l.items)-1, lastVisible,
+		"last item should be visible after deleting from bottom")
+}
+
+func TestScrollOffsetBounds(t *testing.T) {
+	t.Run("empty list", func(t *testing.T) {
+		l := newTestList(0, 50)
+		l.Down()
+		l.Up()
+		assert.Equal(t, 0, l.scrollOffset)
+		assert.Equal(t, 0, l.selectedIdx)
+	})
+
+	t.Run("items fit without scrolling", func(t *testing.T) {
+		// 3 items in a large area — no scroll needed.
+		l := newTestList(3, 80)
+		l.Down()
+		l.Down()
+		_ = l.String()
+		assert.Equal(t, 0, l.scrollOffset, "should not scroll when all items fit")
+	})
+
+	t.Run("scroll offset clamps after multiple deletions", func(t *testing.T) {
+		l := newTestList(10, 30)
+		// Navigate to the end.
+		for i := 0; i < 9; i++ {
+			l.Down()
+		}
+		_ = l.String()
+
+		// Delete items from the end.
+		for len(l.items) > 3 {
+			l.items = l.items[:len(l.items)-1]
+			if l.selectedIdx >= len(l.items) {
+				l.selectedIdx = len(l.items) - 1
+			}
+			if l.scrollOffset >= len(l.items) {
+				l.scrollOffset = len(l.items) - 1
+			}
+			l.clampScrollOffset()
+		}
+		_ = l.String()
+
+		assert.Equal(t, 0, l.scrollOffset,
+			"scroll offset should be 0 when remaining items fit on screen")
+	})
+}


### PR DESCRIPTION
## Summary
- Add `max_instances` field to `config.json` so users can override the default limit of 10 concurrent sessions
- Add viewport scrolling to the session list so items beyond the visible area can be reached via keyboard navigation
- Fix separator line height calculation to maximize visible items in the list
- Clamp scroll offset after item deletion to prevent trailing empty space

## Details

### Configurable max instances
The hard-coded `GlobalInstanceLimit = 10` constant has been replaced with a `max_instances` config field. The default remains 10 for backward compatibility. Existing config files without this field will automatically use the default.

```json
{
  "max_instances": 20
}
```

### Session list scrolling
Previously, when the number of sessions exceeded the visible area, items above/below the viewport were inaccessible. This adds:
- Scroll offset tracking in the `List` struct
- `adjustScrollOffset()` to keep the selected item visible during navigation
- `clampScrollOffset()` to remove trailing empty space after item deletion
- Correct separator line counting (`"\n\n"` adds 1 visible line, not 2)

## Test plan
- [x] `gofmt` — all files formatted
- [x] `go vet` — no issues
- [x] `go test ./...` — all tests pass
- [x] Added unit tests for `MaxInstances` config loading (default, custom value)
- [x] Added unit tests for scroll behavior (up/down, consistent item count, kill last item, edge cases)
- [x] Manual testing with 17 sessions: scroll up/down, delete while scrolled, resize terminal