### PR TITLE
feat: add instance reorder with Shift+J/K

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -747,6 +747,22 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 			m.instanceChanged()
 		})
 		return m, nil
+	case keys.KeyMoveUp:
+		if m.list.MoveUp() {
+			if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
+				return m, m.handleError(err)
+			}
+			return m, m.instanceChanged()
+		}
+		return m, nil
+	case keys.KeyMoveDown:
+		if m.list.MoveDown() {
+			if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
+				return m, m.handleError(err)
+			}
+			return m, m.instanceChanged()
+		}
+		return m, nil
 	case keys.KeyResume:
 		selected := m.list.GetSelectedInstance()
 		if selected == nil || selected.Status == session.Loading {

--- a/app/help.go
+++ b/app/help.go
@@ -44,6 +44,7 @@ func (h helpTypeGeneral) toContent() string {
 		keyStyle.Render("N")+descStyle.Render("         - Create a new session with a prompt"),
 		keyStyle.Render("D")+descStyle.Render("         - Kill (delete) the selected session"),
 		keyStyle.Render("↑/j, ↓/k")+descStyle.Render("  - Navigate between sessions"),
+		keyStyle.Render("J/K")+descStyle.Render("       - Reorder sessions"),
 		keyStyle.Render("↵/o")+descStyle.Render("       - Attach to the selected session"),
 		keyStyle.Render("ctrl-q")+descStyle.Render("    - Detach from session"),
 		"",

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -28,6 +28,10 @@ const (
 	// Diff keybindings
 	KeyShiftUp
 	KeyShiftDown
+
+	// Reorder keybindings
+	KeyMoveUp
+	KeyMoveDown
 )
 
 // GlobalKeyStringsMap is a global, immutable map string to keybinding.
@@ -38,6 +42,8 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"j":          KeyDown,
 	"shift+up":   KeyShiftUp,
 	"shift+down": KeyShiftDown,
+	"J":          KeyMoveDown,
+	"K":          KeyMoveUp,
 	"N":          KeyPrompt,
 	"enter":      KeyEnter,
 	"o":          KeyEnter,
@@ -108,6 +114,15 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 	KeyResume: key.NewBinding(
 		key.WithKeys("r"),
 		key.WithHelp("r", "resume"),
+	),
+
+	KeyMoveUp: key.NewBinding(
+		key.WithKeys("K"),
+		key.WithHelp("K", "move up"),
+	),
+	KeyMoveDown: key.NewBinding(
+		key.WithKeys("J"),
+		key.WithHelp("J", "move down"),
 	),
 
 	// -- Special keybindings --

--- a/ui/list.go
+++ b/ui/list.go
@@ -377,6 +377,26 @@ func (l *List) SelectInstance(target *session.Instance) {
 	}
 }
 
+// MoveUp swaps the selected instance with the one above it.
+func (l *List) MoveUp() bool {
+	if l.selectedIdx <= 0 || len(l.items) < 2 {
+		return false
+	}
+	l.items[l.selectedIdx], l.items[l.selectedIdx-1] = l.items[l.selectedIdx-1], l.items[l.selectedIdx]
+	l.selectedIdx--
+	return true
+}
+
+// MoveDown swaps the selected instance with the one below it.
+func (l *List) MoveDown() bool {
+	if l.selectedIdx >= len(l.items)-1 || len(l.items) < 2 {
+		return false
+	}
+	l.items[l.selectedIdx], l.items[l.selectedIdx+1] = l.items[l.selectedIdx+1], l.items[l.selectedIdx]
+	l.selectedIdx++
+	return true
+}
+
 // GetInstances returns all instances in the list
 func (l *List) GetInstances() []*session.Instance {
 	return l.items

--- a/ui/list.go
+++ b/ui/list.go
@@ -269,6 +269,8 @@ func (l *List) Down() {
 	}
 	if l.selectedIdx < len(l.items)-1 {
 		l.selectedIdx++
+	} else {
+		l.selectedIdx = 0
 	}
 }
 
@@ -313,6 +315,8 @@ func (l *List) Up() {
 	}
 	if l.selectedIdx > 0 {
 		l.selectedIdx--
+	} else {
+		l.selectedIdx = len(l.items) - 1
 	}
 }
 

--- a/ui/list_test.go
+++ b/ui/list_test.go
@@ -1,0 +1,75 @@
+package ui
+
+import (
+	"claude-squad/session"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestList(titles ...string) *List {
+	s := spinner.New()
+	l := NewList(&s, false)
+	for _, t := range titles {
+		inst, _ := session.NewInstance(session.InstanceOptions{
+			Title:   t,
+			Path:    ".",
+			Program: "echo",
+		})
+		l.AddInstance(inst)
+	}
+	return l
+}
+
+func TestMoveUp(t *testing.T) {
+	l := newTestList("a", "b", "c")
+	l.SetSelectedInstance(1) // select "b"
+
+	moved := l.MoveUp()
+	require.True(t, moved)
+	require.Equal(t, 0, l.selectedIdx)
+	require.Equal(t, "b", l.items[0].Title)
+	require.Equal(t, "a", l.items[1].Title)
+	require.Equal(t, "c", l.items[2].Title)
+}
+
+func TestMoveUp_AtTop(t *testing.T) {
+	l := newTestList("a", "b", "c")
+	l.SetSelectedInstance(0)
+
+	moved := l.MoveUp()
+	require.False(t, moved)
+	require.Equal(t, 0, l.selectedIdx)
+	require.Equal(t, "a", l.items[0].Title)
+}
+
+func TestMoveDown(t *testing.T) {
+	l := newTestList("a", "b", "c")
+	l.SetSelectedInstance(1) // select "b"
+
+	moved := l.MoveDown()
+	require.True(t, moved)
+	require.Equal(t, 2, l.selectedIdx)
+	require.Equal(t, "a", l.items[0].Title)
+	require.Equal(t, "c", l.items[1].Title)
+	require.Equal(t, "b", l.items[2].Title)
+}
+
+func TestMoveDown_AtBottom(t *testing.T) {
+	l := newTestList("a", "b", "c")
+	l.SetSelectedInstance(2)
+
+	moved := l.MoveDown()
+	require.False(t, moved)
+	require.Equal(t, 2, l.selectedIdx)
+	require.Equal(t, "c", l.items[2].Title)
+}
+
+func TestMoveWithSingleItem(t *testing.T) {
+	l := newTestList("only")
+	l.SetSelectedInstance(0)
+
+	require.False(t, l.MoveUp())
+	require.False(t, l.MoveDown())
+}


### PR DESCRIPTION
## Summary
- Add Shift+J / Shift+K keybindings to move instances up/down in the list
- New order is persisted to state.json immediately

## Test plan
- [ ] Press `K` (Shift+K) to move selected instance up
- [ ] Press `J` (Shift+J) to move selected instance down
- [ ] Verify boundary cases (top/bottom) are no-ops
- [ ] Restart `cs` and verify reordered list is preserved