### PR TITLE
fix: Refresh preview pane after resume and modal actions

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -755,7 +755,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		if err := selected.Resume(); err != nil {
 			return m, m.handleError(err)
 		}
-		return m, tea.WindowSize()
+		return m, tea.Batch(tea.WindowSize(), m.instanceChanged())
 	case keys.KeyEnter:
 		if m.list.NumInstances() == 0 {
 			return m, nil

--- a/app/app.go
+++ b/app/app.go
@@ -101,6 +101,11 @@ type home struct {
 	textOverlay *overlay.TextOverlay
 	// confirmationOverlay displays confirmation modals
 	confirmationOverlay *overlay.ConfirmationOverlay
+	// pendingMsg holds a tea.Msg produced by a confirmation action while a
+	// modal is closing. handleKeyPress drains it back into the event loop
+	// when the overlay dismisses, so action results (errors, refresh
+	// signals) are not lost between the OnConfirm callback and Update.
+	pendingMsg tea.Msg
 }
 
 func newHome(ctx context.Context, program string, autoYes bool) *home {
@@ -566,6 +571,11 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		if shouldClose {
 			m.state = stateDefault
 			m.confirmationOverlay = nil
+			if m.pendingMsg != nil {
+				pending := m.pendingMsg
+				m.pendingMsg = nil
+				return m, func() tea.Msg { return pending }
+			}
 			return m, nil
 		}
 		return m, nil
@@ -1003,7 +1013,7 @@ func (m *home) confirmAction(message string, action tea.Cmd) tea.Cmd {
 		m.state = stateDefault
 		// Execute the action if it exists
 		if action != nil {
-			_ = action()
+			m.pendingMsg = action()
 		}
 	}
 


### PR DESCRIPTION
The preview pane keeps a cached `previewState` that only changes when `m.instanceChanged()` runs. Two lifecycle events were not triggering that call, so the pane stayed frozen on stale text until the next `previewTickMsg` (or until the user pressed Up/Down, which has its own explicit `instanceChanged` call).

- **Root cause (Resume)**: `case keys.KeyResume` in `app/app.go` returns `tea.WindowSize()` only, while the corresponding `case keys.KeyCheckout` (pause) calls `instanceChanged()` after `Pause()`.
- **Fix (Resume)**: Batch `m.instanceChanged()` alongside `tea.WindowSize()` in the resume return, matching the shape used by `case startInstanceMsg` in the same file.

- **Root cause (Kill / confirmation modal)**: `confirmAction`'s `OnConfirm` callback discards the `tea.Msg` returned by the action (`_ = action()`). The kill path's `instanceChangedMsg{}` is dropped, so the preview pane keeps the killed instance's paused fallback. The push path's error returns are dropped the same way.
- **Fix (Kill / confirmation modal)**: Stash the action's returned message on a new `home.pendingMsg` field inside `OnConfirm`, then drain it back into the event loop from the `stateConfirm` branch of `handleKeyPress` when the overlay dismisses. The existing `case instanceChangedMsg:` and `case error:` handlers do the rest.

Tested by:
- Pausing and resuming an instance with `c` then `r`; preview redraws to live tmux content on the same frame instead of one tick later.
- Pausing then killing an instance with `c` then `D`; preview redraws to the new selected instance immediately instead of staying stuck on the killed instance's paused fallback.
- Triggering a `P` (push) failure; the error now appears in the err box instead of being silently swallowed.