### PR TITLE
fix: use actual binary name in completion scripts

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/spf13/cobra"
@@ -22,6 +23,7 @@ var (
 	programFlag string
 	autoYesFlag bool
 	daemonFlag  bool
+	binName     string
 	rootCmd     = &cobra.Command{
 		Use:   "claude-squad",
 		Short: "Claude Squad - Manage multiple AI agents like Claude Code, Aider, Codex, and Amp.",
@@ -44,7 +46,7 @@ var (
 			}
 
 			if !git.IsGitRepo(currentDir) {
-				return fmt.Errorf("error: claude-squad must be run from within a git repository")
+				return fmt.Errorf("error: %s must be run from within a git repository", binName)
 			}
 
 			cfg := config.LoadConfig()
@@ -135,9 +137,9 @@ var (
 
 	versionCmd = &cobra.Command{
 		Use:   "version",
-		Short: "Print the version number of claude-squad",
+		Short: "Print the version number",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("claude-squad version %s\n", version)
+			fmt.Printf("%s version %s\n", binName, version)
 			fmt.Printf("https://github.com/smtg-ai/claude-squad/releases/tag/v%s\n", version)
 		},
 	}
@@ -163,6 +165,10 @@ func init() {
 }
 
 func main() {
+	// Extract the binary name from how this was invoked
+	binName = filepath.Base(os.Args[0])
+	rootCmd.Use = binName
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 	}


### PR DESCRIPTION
## Summary
Fixed completion scripts and error messages to use the actual invoked binary name instead of hardcoding 'claude-squad'.

- Fish, bash, and zsh completion scripts now work with custom binary names (e.g., `--name cs`)
- Error messages and help text now reference the actual binary name
- Completion generation dynamically extracts the binary name from `os.Args[0]`

## Problem
When users installed claude-squad with a custom name (e.g., `install.sh --name cs`), the generated completion scripts still referenced `claude-squad`, making them non-functional.

## Solution
Modified `main.go` to:
1. Extract the actual binary name from `os.Args[0]` using `filepath.Base()`
2. Dynamically set `rootCmd.Use` to this binary name before Cobra generates completions
3. Update error messages and version output to use the actual binary name

This ensures all three completion shells (fish, bash, zsh) work correctly regardless of how the binary is named.