### PR TITLE
fix: validate detected claude command before using it as default_program

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -129,17 +129,9 @@ func GetClaudeCommand() (string, error) {
 
 	cmd := exec.Command(shell, "-c", shellCmd)
 	output, err := cmd.Output()
-	if err == nil && len(output) > 0 {
-		path := strings.TrimSpace(string(output))
-		if path != "" {
-			// Check if the output is an alias definition and extract the actual path
-			// Handle formats like "claude: aliased to /path/to/claude" or other shell-specific formats
-			aliasRegex := regexp.MustCompile(`(?:aliased to|->|=)\s*([^\s]+)`)
-			matches := aliasRegex.FindStringSubmatch(path)
-			if len(matches) > 1 {
-				path = matches[1]
-			}
-			return path, nil
+	if err == nil {
+		if program, ok := resolveClaudeCandidate(string(output)); ok {
+			return program, nil
 		}
 	}
 
@@ -150,6 +142,36 @@ func GetClaudeCommand() (string, error) {
 	}
 
 	return "", fmt.Errorf("claude command not found in aliases or PATH")
+}
+
+// resolveClaudeCandidate interprets the output of `which claude` and returns a
+// usable program path. The output may be a plain path, an alias definition
+// (e.g. "claude: aliased to /usr/local/bin/claude"), or — when `claude` is a
+// shell function — the full multi-line function body. We extract the alias
+// target when present, then require the result to resolve to a real executable
+// via exec.LookPath. If it does not (as happens with a function body, where the
+// alias regex can capture a non-path token such as "$?"), we report no match so
+// the caller falls back to a direct PATH lookup instead of persisting an
+// unrunnable program as default_program — which otherwise causes new sessions to
+// fail with "timed out waiting for tmux session ... (cleanup error: ...)".
+func resolveClaudeCandidate(whichOutput string) (string, bool) {
+	path := strings.TrimSpace(whichOutput)
+	if path == "" {
+		return "", false
+	}
+
+	// Extract the target if the output is an alias definition.
+	// Handle formats like "claude: aliased to /path/to/claude" or other shell-specific formats.
+	aliasRegex := regexp.MustCompile(`(?:aliased to|->|=)\s*([^\s]+)`)
+	if matches := aliasRegex.FindStringSubmatch(path); len(matches) > 1 {
+		path = matches[1]
+	}
+
+	// Only trust the candidate if it actually resolves to an executable.
+	if resolved, lookErr := exec.LookPath(path); lookErr == nil {
+		return resolved, true
+	}
+	return "", false
 }
 
 func LoadConfig() *Config {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -98,6 +98,62 @@ func TestGetClaudeCommand(t *testing.T) {
 	})
 }
 
+func TestResolveClaudeCandidate(t *testing.T) {
+	// Provide a real, executable `claude` on PATH so the candidates that are
+	// expected to resolve can succeed.
+	tempDir := t.TempDir()
+	claudePath := filepath.Join(tempDir, "claude")
+	require.NoError(t, os.WriteFile(claudePath, []byte("#!/bin/sh\n"), 0o755))
+
+	originalPath := os.Getenv("PATH")
+	os.Setenv("PATH", tempDir+string(os.PathListSeparator)+originalPath)
+	t.Cleanup(func() { os.Setenv("PATH", originalPath) })
+
+	// The multi-line body `which claude` prints when `claude` is a zsh function.
+	// The alias regex captures "$?" from `local ret=$?`; that token is not a
+	// runnable program, so resolution must report no match (regression for the
+	// "timed out waiting for tmux session" failure).
+	functionBody := "claude () {\n" +
+		"\tif [[ -n \"$TMUX\" ]]\n" +
+		"\tthen\n" +
+		"\t\ttmux setw monitor-activity off\n" +
+		"\t\tcommand claude \"$@\"\n" +
+		"\t\tlocal ret=$?\n" +
+		"\t\ttmux setw monitor-activity on\n" +
+		"\t\treturn $ret\n" +
+		"\telse\n" +
+		"\t\tcommand claude \"$@\"\n" +
+		"\tfi\n" +
+		"}"
+
+	tests := []struct {
+		name     string
+		output   string
+		wantOK   bool
+		wantPath string
+	}{
+		{"plain absolute path", claudePath, true, claudePath},
+		{"alias definition", "claude: aliased to " + claudePath, true, claudePath},
+		{"bare name resolved via PATH", "claude", true, claudePath},
+		{"shell function body is rejected", functionBody, false, ""},
+		{"empty output", "   \n\t", false, ""},
+		{"non-executable alias target", "claude=/nonexistent/definitely/not/here", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := resolveClaudeCandidate(tt.output)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantPath, got)
+			} else {
+				assert.Empty(t, got)
+				assert.NotEqual(t, "$?", got, "must never return the mis-parsed function-body token")
+			}
+		})
+	}
+}
+
 func TestDefaultConfig(t *testing.T) {
 	t.Run("creates config with default values", func(t *testing.T) {
 		config := DefaultConfig()


### PR DESCRIPTION
## Problem

On first run (no `config.json`), `GetClaudeCommand()` runs `which claude` and returns the parsed result as `default_program` **without verifying it is an executable**.

When `claude` is defined as a **shell function** (common for wrappers), zsh's `which` builtin prints the full multi-line function body. The alias regex `(?:aliased to|->|=)\s*([^\s]+)` then matches the leftmost `=` — e.g. in `local ret=$?` — and captures `$?`, which gets persisted as `default_program`. Every new session launches `$?`, which is not a runnable command, so the pane process exits immediately and session creation fails with:

`failed to start new session: timed out waiting for tmux session claudesquad_<name>: <nil> (cleanup error: killing tmux session: exit status 1)`

This is the same user-visible error as the previously-closed #96, #115, and #132, but with a distinct root cause (a shell *function* body, which the existing alias handling doesn't cover).

## Fix

Extract `resolveClaudeCandidate()`, which extracts the alias target when present and then requires the result to resolve via `exec.LookPath` before trusting it. If it doesn't resolve (as with a function body), `GetClaudeCommand` falls through to the existing `exec.LookPath("claude")` PATH lookup — and ultimately the `defaultProgram = "claude"` default. This reuses validation already present in the function, adds no dependencies, preserves the genuine alias-path optimization, and neutralizes function bodies / malformed aliases / any unexpected `which` output.

## Tests

Added `TestResolveClaudeCandidate` (table-driven): plain path, alias definition, bare-name PATH resolution, empty output, a non-executable alias target, and a zsh **function body** that previously produced `$?` — now asserted to be rejected. `go test ./...`, `go vet`, and `gofmt -l` are all clean.

## Reproduce

```console
$ zsh -c 'source ~/.zshrc &>/dev/null || true; which claude'
claude () {
	...
	local ret=$?
	...
}
# old behavior: config.json -> "default_program": "$?"
```
