### PR TITLE
fix: preserve original case in branch names

### DIFF
--- a/session/git/util.go
+++ b/session/git/util.go
@@ -11,15 +11,12 @@ import (
 // Note: Git branch names have several rules, so this function uses a simple approach
 // by allowing only a safe subset of characters.
 func sanitizeBranchName(s string) string {
-	// Convert to lower-case
-	s = strings.ToLower(s)
-
 	// Replace spaces with a dash
 	s = strings.ReplaceAll(s, " ", "-")
 
 	// Remove any characters not allowed in our safe subset.
 	// Here we allow: letters, digits, dash, underscore, slash, and dot.
-	re := regexp.MustCompile(`[^a-z0-9\-_/.]+`)
+	re := regexp.MustCompile(`[^a-zA-Z0-9\-_/.]+`)
 	s = re.ReplaceAllString(s, "")
 
 	// Replace multiple dashes with a single dash (optional cleanup)

--- a/session/git/util_test.go
+++ b/session/git/util_test.go
@@ -23,7 +23,7 @@ func TestSanitizeBranchName(t *testing.T) {
 		{
 			name:     "mixed case string",
 			input:    "FeAtUrE BrAnCh",
-			expected: "feature-branch",
+			expected: "FeAtUrE-BrAnCh",
 		},
 		{
 			name:     "string with special characters",
@@ -58,7 +58,7 @@ func TestSanitizeBranchName(t *testing.T) {
 		{
 			name:     "complex mixed case with special chars",
 			input:    "USER/Feature Branch!@#$%^&*()/v1.0",
-			expected: "user/feature-branch/v1.0",
+			expected: "USER/Feature-Branch/v1.0",
 		},
 	}
 


### PR DESCRIPTION
## Problem
Branch names are silently converted to lowercase by `sanitizeBranchName()`.
For example, entering `JRA-123` results in branch `jra-123`.
This may not match the user's intended naming convention.

According to Atlassian's official documentation, Jira work item keys must use
capital letters to link correctly with development tools:
https://support.atlassian.com/jira-software-cloud/docs/reference-issues-in-your-development-work/

## Root Cause
`sanitizeBranchName()` calls `strings.ToLower()` and uses a regex that only
allows lowercase letters `[^a-z0-9\-_/.]`, which together silently discard
uppercase characters. The scope of this function could be limited to removing
git-invalid characters, leaving case normalization to the user's preference.

## Fix
- Remove `strings.ToLower()` call
- Update regex from `[^a-z0-9\-_/.]` to `[^a-zA-Z0-9\-_/.]`
  to allow uppercase letters after removing the lowercasing step

## Reproduction
1. Create a session with name `JRA-123`
2. Run `git worktree list`
3. Branch name is `jra-123` instead of `JRA-123`