### PR TITLE
feat: auto-approve GitHub Copilot in auto-yes mode

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -626,6 +626,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 			Title:   "",
 			Path:    ".",
 			Program: m.program,
+			AutoYes: m.autoYes,
 		})
 		if err != nil {
 			return m, m.handleError(err)
@@ -647,6 +648,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 			Title:   "",
 			Path:    ".",
 			Program: m.program,
+			AutoYes: m.autoYes,
 		})
 		if err != nil {
 			return m, m.handleError(err)

--- a/session/instance.go
+++ b/session/instance.go
@@ -135,7 +135,7 @@ func FromInstanceData(data InstanceData) (*Instance, error) {
 
 	if instance.Paused() {
 		instance.started = true
-		instance.tmuxSession = tmux.NewTmuxSession(instance.Title, instance.Program)
+		instance.tmuxSession = tmux.NewTmuxSession(instance.Title, tmux.AutoYesProgram(instance.Program, data.AutoYes))
 	} else {
 		if err := instance.Start(false); err != nil {
 			return nil, err
@@ -153,7 +153,9 @@ type InstanceOptions struct {
 	Path string
 	// Program is the program to run in the instance (e.g. "claude", "aider --model ollama_chat/gemma3:1b")
 	Program string
-	// If AutoYes is true, then
+	// AutoYes, when true, runs the instance autonomously: prompts are
+	// auto-accepted and, for agents that support it, auto-approve flags are
+	// added to the launch command (see tmux.AutoYesProgram).
 	AutoYes bool
 	// Branch is an existing branch name to start the session on (empty = new branch from HEAD)
 	Branch string
@@ -177,7 +179,7 @@ func NewInstance(opts InstanceOptions) (*Instance, error) {
 		Width:          0,
 		CreatedAt:      t,
 		UpdatedAt:      t,
-		AutoYes:        false,
+		AutoYes:        opts.AutoYes,
 		selectedBranch: opts.Branch,
 	}, nil
 }
@@ -210,7 +212,7 @@ func (i *Instance) Start(firstTimeSetup bool) error {
 		tmuxSession = i.tmuxSession
 	} else {
 		// Create new tmux session
-		tmuxSession = tmux.NewTmuxSession(i.Title, i.Program)
+		tmuxSession = tmux.NewTmuxSession(i.Title, tmux.AutoYesProgram(i.Program, i.AutoYes))
 	}
 	i.tmuxSession = tmuxSession
 

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -23,6 +24,54 @@ const ProgramClaude = "claude"
 
 const ProgramAider = "aider"
 const ProgramGemini = "gemini"
+const ProgramCopilot = "copilot"
+
+// GitHub Copilot CLI auto-approve flags. In autonomous (auto-yes) mode these
+// stop it from blocking on its trust/permission prompt and from pausing to ask
+// the user questions. The broader --allow-all / --yolo flags (allow-all-tools +
+// allow-all-paths + allow-all-urls) are treated as already covering tool
+// approval when a user has configured them.
+const copilotAllowAllToolsFlag = "--allow-all-tools"
+const copilotNoAskUserFlag = "--no-ask-user"
+
+// AutoYesProgram returns the program command to launch for an autonomous
+// (auto-yes) session. For agents that expose non-interactive auto-approve flags
+// it appends them so the agent does not stall on a trust or permission prompt.
+// Currently this is needed for GitHub Copilot. For every other program, and
+// when autoYes is false, program is returned unchanged. The function is
+// idempotent: it never appends a flag that is already present.
+func AutoYesProgram(program string, autoYes bool) string {
+	if !autoYes {
+		return program
+	}
+	fields := strings.Fields(program)
+	if len(fields) == 0 || filepath.Base(fields[0]) != ProgramCopilot {
+		return program
+	}
+
+	result := program
+	// --allow-all and --yolo already imply --allow-all-tools, so only add the
+	// tool-approval flag when none of them is set.
+	if !hasArg(fields, copilotAllowAllToolsFlag) &&
+		!hasArg(fields, "--allow-all") &&
+		!hasArg(fields, "--yolo") {
+		result += " " + copilotAllowAllToolsFlag
+	}
+	if !hasArg(fields, copilotNoAskUserFlag) {
+		result += " " + copilotNoAskUserFlag
+	}
+	return result
+}
+
+// hasArg reports whether args contains the exact flag.
+func hasArg(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
 
 // TmuxSession represents a managed tmux session
 type TmuxSession struct {

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -86,3 +86,53 @@ func TestStartTmuxSession(t *testing.T) {
 	_, err = ptyFactory.files[1].Stat()
 	require.NoError(t, err)
 }
+
+func TestAutoYesProgram(t *testing.T) {
+	cases := []struct {
+		name    string
+		program string
+		autoYes bool
+		want    string
+	}{
+		{"copilot gets auto-approve flags", "copilot", true, "copilot --allow-all-tools --no-ask-user"},
+		{"copilot unchanged without auto-yes", "copilot", false, "copilot"},
+		{"copilot full path", "/opt/homebrew/bin/copilot", true, "/opt/homebrew/bin/copilot --allow-all-tools --no-ask-user"},
+		{"copilot keeps model passthrough", "copilot --model gpt-5.4", true, "copilot --model gpt-5.4 --allow-all-tools --no-ask-user"},
+		{"copilot is idempotent", "copilot --allow-all-tools --no-ask-user", true, "copilot --allow-all-tools --no-ask-user"},
+		{"copilot yolo already implies allow-all-tools", "copilot --yolo", true, "copilot --yolo --no-ask-user"},
+		{"claude is left untouched", "claude", true, "claude"},
+		{"empty program", "", true, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, AutoYesProgram(tc.program, tc.autoYes))
+		})
+	}
+}
+
+func TestStartTmuxSessionCopilotAutoYes(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+
+	created := false
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") && !created {
+				created = true
+				return fmt.Errorf("session already exists")
+			}
+			return nil
+		},
+		OutputFunc: func(cmd *exec.Cmd) ([]byte, error) {
+			return []byte("output"), nil
+		},
+	}
+
+	workdir := t.TempDir()
+	program := AutoYesProgram("copilot", true)
+	session := newTmuxSession("test-session", program, ptyFactory, cmdExec)
+
+	err := session.Start(workdir)
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf("tmux new-session -d -s claudesquad_test-session -c %s copilot --allow-all-tools --no-ask-user", workdir),
+		cmd2.ToString(ptyFactory.cmds[0]))
+}


### PR DESCRIPTION
## What

Makes GitHub Copilot a first-class agent for autonomous (auto-yes) sessions. claude-squad launches each agent's command verbatim in tmux, so an auto-yes Copilot session currently stalls on Copilot's interactive trust/permission prompt with nothing to dismiss it.

When a session runs in auto-yes mode and the configured program is `copilot`, the launch command now gets Copilot's auto-approve flags appended:

    copilot  ->  copilot --allow-all-tools --no-ask-user

so the agent runs to completion without blocking.

## How

- New `tmux.AutoYesProgram(program, autoYes)` helper (`session/tmux/tmux.go`), gated on a new `ProgramCopilot` constant, mirroring how the repo already special-cases agents by program name. It is idempotent, recognizes a user-configured `--allow-all`/`--yolo`, and leaves every other program (claude, aider, gemini, codex, ...) untouched.
- `NewInstance` now honors the existing `InstanceOptions.AutoYes` field so the auto-yes intent is known at launch; the two session-creation sites in `app/app.go` pass the global auto-yes flag through.
- The transform is applied at every tmux launch site (new session and paused-session resume).

The flags are verified against GitHub Copilot CLI v1.0.65 (`--allow-all-tools` = allow all tools to run automatically, `--no-ask-user` = disable the ask_user tool).

## Testing (on this machine)

- `go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run` (v1.60.1, the CI-pinned version), and `go test ./...` all pass.
- `TestAutoYesProgram` (8 cases) and `TestStartTmuxSessionCopilotAutoYes` assert the exact tmux argv built for copilot in auto-yes mode: `tmux new-session -d -s <name> -c <workdir> copilot --allow-all-tools --no-ask-user`.
- The flags themselves were confirmed present in `copilot --help` v1.0.65.

## Notes

- Scope: the interactive trust-prompt pane-scraping path used for Claude/aider/gemini was intentionally not added for Copilot, because the flag-based approach is robust and Copilot's exact interactive prompt strings are not verified here. Model passthrough is preserved (any `--model ...` the user sets is kept).
