### PR TITLE
fix: add confirmation prompt to cs reset command

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"claude-squad/app"
 	cmd2 "claude-squad/cmd"
 	"claude-squad/config"
@@ -14,17 +15,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 var (
-	version     = "1.0.19"
-	programFlag string
-	autoYesFlag bool
-	daemonFlag  bool
-	binName     string
-	rootCmd     = &cobra.Command{
+	version        = "1.0.19"
+	programFlag    string
+	autoYesFlag    bool
+	daemonFlag     bool
+	resetForceFlag bool
+	binName        string
+	rootCmd        = &cobra.Command{
 		Use:   "claude-squad",
 		Short: "Claude Squad - Manage multiple AI agents like Claude Code, Aider, Codex, and Amp.",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -83,6 +86,17 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log.Initialize(false)
 			defer log.Close()
+
+			if !resetForceFlag {
+				confirmed, err := confirmReset()
+				if err != nil {
+					return err
+				}
+				if !confirmed {
+					fmt.Println("Aborted.")
+					return nil
+				}
+			}
 
 			state := config.LoadState()
 			storage, err := session.NewStorage(state)
@@ -145,6 +159,32 @@ var (
 	}
 )
 
+// confirmReset warns the user about the destructive nature of `reset` and
+// prompts for confirmation. It returns true if the user confirmed.
+func confirmReset() (bool, error) {
+	dirtyCount, err := git.CountWorktreesWithUncommittedChanges()
+	if err != nil {
+		log.ErrorLog.Printf("failed to check worktrees for uncommitted changes: %v", err)
+	}
+
+	fmt.Println("Warning: This will permanently delete all sessions and worktrees.")
+	if dirtyCount > 0 {
+		fmt.Printf("%d worktree(s) have uncommitted changes that will be lost and cannot be recovered.\n", dirtyCount)
+	} else {
+		fmt.Println("Uncommitted changes will be lost and cannot be recovered.")
+	}
+	fmt.Print("Are you sure? (y/N): ")
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil && input == "" {
+		return false, fmt.Errorf("failed to read confirmation input: %w", err)
+	}
+	input = strings.TrimSpace(strings.ToLower(input))
+
+	return input == "y" || input == "yes", nil
+}
+
 func init() {
 	rootCmd.Flags().StringVarP(&programFlag, "program", "p", "",
 		"Program to run in new instances (e.g. 'aider --model ollama_chat/gemma3:1b')")
@@ -158,6 +198,9 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	resetCmd.Flags().BoolVarP(&resetForceFlag, "force", "y", false,
+		"Skip the confirmation prompt (useful for scripting)")
 
 	rootCmd.AddCommand(debugCmd)
 	rootCmd.AddCommand(versionCmd)

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -155,6 +155,43 @@ func (g *GitWorktree) Prune() error {
 	return nil
 }
 
+// CountWorktreesWithUncommittedChanges returns the number of worktrees under the
+// worktrees directory that currently have uncommitted changes.
+func CountWorktreesWithUncommittedChanges() (int, error) {
+	worktreesDir, err := getWorktreeDirectory()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get worktree directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(worktreesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to read worktree directory: %w", err)
+	}
+
+	count := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		worktreePath := filepath.Join(worktreesDir, entry.Name())
+		cmd := exec.Command("git", "-C", worktreePath, "status", "--porcelain")
+		output, err := cmd.Output()
+		if err != nil {
+			// Skip entries that are no longer valid git working trees.
+			continue
+		}
+		if len(output) > 0 {
+			count++
+		}
+	}
+
+	return count, nil
+}
+
 // CleanupWorktrees removes all worktrees and their associated branches
 func CleanupWorktrees() error {
 	worktreesDir, err := getWorktreeDirectory()

--- a/session/git/worktree_ops_test.go
+++ b/session/git/worktree_ops_test.go
@@ -68,6 +68,74 @@ func TestSetupFromExistingBranch_RemovesOrphanedDirectory(t *testing.T) {
 	}
 }
 
+func TestCountWorktreesWithUncommittedChanges(t *testing.T) {
+	tempHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", tempHome); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	defer func() {
+		_ = os.Setenv("HOME", originalHome)
+	}()
+
+	worktreesDir := filepath.Join(tempHome, ".claude-squad", "worktrees")
+	if err := os.MkdirAll(worktreesDir, 0755); err != nil {
+		t.Fatalf("mkdir worktrees dir: %v", err)
+	}
+
+	// A clean worktree: initialized, committed, no pending changes.
+	cleanPath := filepath.Join(worktreesDir, "clean")
+	mustRunGit(t, "", "init", cleanPath)
+	mustRunGit(t, cleanPath, "config", "user.name", "Test User")
+	mustRunGit(t, cleanPath, "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(cleanPath, "README.md"), []byte("hello\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	mustRunGit(t, cleanPath, "add", "README.md")
+	mustRunGit(t, cleanPath, "commit", "-m", "initial")
+
+	// A dirty worktree: has an uncommitted change.
+	dirtyPath := filepath.Join(worktreesDir, "dirty")
+	mustRunGit(t, "", "init", dirtyPath)
+	mustRunGit(t, dirtyPath, "config", "user.name", "Test User")
+	mustRunGit(t, dirtyPath, "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(dirtyPath, "README.md"), []byte("hello\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	mustRunGit(t, dirtyPath, "add", "README.md")
+	mustRunGit(t, dirtyPath, "commit", "-m", "initial")
+	if err := os.WriteFile(filepath.Join(dirtyPath, "README.md"), []byte("modified\n"), 0644); err != nil {
+		t.Fatalf("modify README: %v", err)
+	}
+
+	count, err := CountWorktreesWithUncommittedChanges()
+	if err != nil {
+		t.Fatalf("CountWorktreesWithUncommittedChanges() error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("count = %d, want 1", count)
+	}
+}
+
+func TestCountWorktreesWithUncommittedChanges_NoWorktreesDir(t *testing.T) {
+	tempHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", tempHome); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	defer func() {
+		_ = os.Setenv("HOME", originalHome)
+	}()
+
+	count, err := CountWorktreesWithUncommittedChanges()
+	if err != nil {
+		t.Fatalf("CountWorktreesWithUncommittedChanges() error = %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("count = %d, want 0", count)
+	}
+}
+
 func mustRunGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 


### PR DESCRIPTION
## Problem
`cs reset` permanently deletes all sessions and worktrees without any
confirmation prompt. Uncommitted work cannot be recovered after reset.

## Fix
- Add a confirmation prompt before executing reset
- Warn if worktrees with uncommitted changes exist
- Add `--force` / `-y` flag to skip confirmation for scripting use cases