### PR TITLE
fix: record base commit for existing-branch sessions

### DIFF
--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -56,7 +56,7 @@ func (g *GitWorktree) setupFromExistingBranch() error {
 		if _, err := g.runGitCommand(g.repoPath, "worktree", "add", "-b", g.branchName, g.worktreePath, fmt.Sprintf("origin/%s", g.branchName)); err != nil {
 			return fmt.Errorf("failed to create worktree from remote branch %s: %w", g.branchName, err)
 		}
-		return nil
+		return g.recordBaseCommit()
 	}
 
 	// Create a new worktree from the existing local branch
@@ -64,6 +64,18 @@ func (g *GitWorktree) setupFromExistingBranch() error {
 		return fmt.Errorf("failed to create worktree from branch %s: %w", g.branchName, err)
 	}
 
+	return g.recordBaseCommit()
+}
+
+// recordBaseCommit stores the commit the session starts from. Diffs are computed
+// against it, so leaving it unset makes every git diff invocation fail with an
+// ambiguous argument error once the session is running.
+func (g *GitWorktree) recordBaseCommit() error {
+	output, err := g.runGitCommand(g.worktreePath, "rev-parse", "HEAD")
+	if err != nil {
+		return fmt.Errorf("failed to get base commit hash for branch %s: %w", g.branchName, err)
+	}
+	g.baseCommitSHA = strings.TrimSpace(output)
 	return nil
 }
 

--- a/session/git/worktree_ops_test.go
+++ b/session/git/worktree_ops_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -65,6 +66,47 @@ func TestSetupFromExistingBranch_RemovesOrphanedDirectory(t *testing.T) {
 	currentBranch := mustRunGit(t, worktreePath, "branch", "--show-current")
 	if currentBranch != "feature/test\n" {
 		t.Fatalf("current branch = %q, want %q", currentBranch, "feature/test\n")
+	}
+}
+
+func TestSetupFromExistingBranch_RecordsBaseCommit(t *testing.T) {
+	tempHome := t.TempDir()
+	originalHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", tempHome); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+	defer func() {
+		_ = os.Setenv("HOME", originalHome)
+	}()
+
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	mustRunGit(t, "", "init", repoPath)
+	mustRunGit(t, repoPath, "config", "user.name", "Test User")
+	mustRunGit(t, repoPath, "config", "user.email", "test@example.com")
+
+	readmePath := filepath.Join(repoPath, "README.md")
+	if err := os.WriteFile(readmePath, []byte("hello\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+
+	mustRunGit(t, repoPath, "add", "README.md")
+	mustRunGit(t, repoPath, "commit", "-m", "initial")
+	mustRunGit(t, repoPath, "branch", "feature/test")
+
+	g := &GitWorktree{
+		repoPath:         repoPath,
+		worktreePath:     filepath.Join(tempHome, ".claude-squad", "worktrees", "feature-test"),
+		branchName:       "feature/test",
+		isExistingBranch: true,
+	}
+
+	if err := g.Setup(); err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+
+	want := strings.TrimSpace(mustRunGit(t, repoPath, "rev-parse", "feature/test"))
+	if got := g.GetBaseCommitSHA(); got != want {
+		t.Fatalf("GetBaseCommitSHA() = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Problem

Sessions created from a **pre-existing branch** never get a base commit recorded, which makes the TUI log an error roughly twice a second for the lifetime of the session:

```
WARNING app.go:253: could not update diff stats: git command failed:
fatal: ambiguous argument '': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
 (exit status 128)
```

`setupNewWorktree` resolves `HEAD` and assigns `g.baseCommitSHA`, but `setupFromExistingBranch` returns without ever setting it — on both the local-branch and remote-tracking paths:

```go
// Create a new worktree from the existing local branch
if _, err := g.runGitCommand(g.repoPath, "worktree", "add", g.worktreePath, g.branchName); err != nil {
    return fmt.Errorf("failed to create worktree from branch %s: %w", g.branchName, err)
}

return nil   // baseCommitSHA is still ""
```

`diff.go` then runs `git diff ""`, which exits 128 on every refresh:

```go
content, err := g.runGitCommand(g.worktreePath, "--no-pager", "diff", g.GetBaseCommitSHA())
```

The instance persists to `state.json` with `"base_commit_sha": ""`, so restarting does not clear it — the session is permanently stuck producing failed subprocess calls, and its diff tab stays empty.

## Reproduction

1. In a repo with an existing branch, create a session and select that branch as the source (the `is_existing_branch` path added in #262).
2. `cat ~/.claude-squad/state.json` — the instance shows `"base_commit_sha": ""`.
3. Watch the log at the path printed by `cs debug`; the warning above repeats continuously.

## Fix

Both paths in `setupFromExistingBranch` now resolve the worktree `HEAD` and store it, so "base" means the same thing it already means for new branches: the commit the session started from.

## Testing

Added `TestSetupFromExistingBranch_RecordsBaseCommit`, which builds a real repo, runs `Setup()` with `isExistingBranch: true`, and asserts the recorded SHA matches the branch tip.

Verified it fails without the production change:

```
--- FAIL: TestSetupFromExistingBranch_RecordsBaseCommit
    worktree_ops_test.go:109: GetBaseCommitSHA() = "", want "b93ed4f66fba0eb41fd3ef9475c686e4671635ad"
```

`go test ./...` passes and `gofmt -l .` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
