### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,4 +159,4 @@ underlying program (ex. `claude`) to the latest version.
 
 ### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=smtg-ai/claude-squad&type=Date)](https://www.star-history.com/#smtg-ai/claude-squad&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=smtg-ai/claude-squad&type=Date)](https://star-history.dera.page/#smtg-ai/claude-squad&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken: GitHub's stargazer API restrictions have made the underlying data unavailable, so the chart no longer renders.

This change moves the chart to an alternative service that uses a different data source requiring no API token, restoring the chart without any configuration needed.