### PR TITLE
fix: recover instances whose tmux session died with the server

### DIFF
--- a/session/instance.go
+++ b/session/instance.go
@@ -4,6 +4,7 @@ import (
 	"claude-squad/log"
 	"claude-squad/session/git"
 	"claude-squad/session/tmux"
+	"errors"
 	"path/filepath"
 
 	"fmt"
@@ -245,8 +246,18 @@ func (i *Instance) Start(firstTimeSetup bool) error {
 	}()
 
 	if !firstTimeSetup {
-		// Reuse existing session
+		// Reuse existing session. If the tmux server died since we last ran (reboot,
+		// crash, `tmux kill-server`), the session is gone but the worktree and branch
+		// are still on disk. Park the instance as Paused so Resume can rebuild it.
+		// Reporting an error here would be worse than useless: LoadInstances aborts on
+		// the first failure, so a single dead session would hide every other instance.
 		if err := tmuxSession.Restore(); err != nil {
+			if errors.Is(err, tmux.ErrSessionNotFound) {
+				log.WarningLog.Printf(
+					"tmux session for %q no longer exists; pausing instance so it can be resumed", i.Title)
+				i.SetStatus(Paused)
+				return nil
+			}
 			setupErr = fmt.Errorf("failed to restore existing session: %w", err)
 			return setupErr
 		}
@@ -512,10 +523,19 @@ func (i *Instance) Resume() error {
 		return fmt.Errorf("cannot resume: branch is checked out, please switch to a different branch")
 	}
 
-	// Setup git worktree
-	if err := i.gitWorktree.Setup(); err != nil {
-		log.ErrorLog.Print(err)
-		return fmt.Errorf("failed to setup git worktree: %w", err)
+	// Setup git worktree. Setup removes and re-adds the worktree from the branch, which
+	// throws away anything uncommitted in it. After a normal Pause the directory is gone
+	// and that is exactly what we want; but an instance paused because its tmux session
+	// died still has its worktree — and the work in it — sitting on disk, so leave it be.
+	if valid, err := i.gitWorktree.IsValidWorktree(); err != nil || !valid {
+		if err != nil {
+			log.WarningLog.Printf("could not validate worktree at %s, recreating it: %v",
+				i.gitWorktree.GetWorktreePath(), err)
+		}
+		if err := i.gitWorktree.Setup(); err != nil {
+			log.ErrorLog.Print(err)
+			return fmt.Errorf("failed to setup git worktree: %w", err)
+		}
 	}
 
 	// Check if tmux session still exists from pause, otherwise create new one

--- a/session/instance_test.go
+++ b/session/instance_test.go
@@ -1,0 +1,76 @@
+package session
+
+import (
+	"claude-squad/cmd/cmd_test"
+	"claude-squad/log"
+	"claude-squad/session/tmux"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	log.Initialize(false)
+	defer log.Close()
+	os.Exit(m.Run())
+}
+
+// nullPtyFactory hands back a throwaway file instead of a real PTY.
+type nullPtyFactory struct {
+	t     *testing.T
+	calls int
+}
+
+func (p *nullPtyFactory) Start(cmd *exec.Cmd) (*os.File, error) {
+	p.calls++
+	return os.OpenFile(filepath.Join(p.t.TempDir(), "pty"), os.O_CREATE|os.O_RDWR, 0644)
+}
+
+func (p *nullPtyFactory) Close() {}
+
+// When the tmux server dies between runs, every session goes with it while the worktree
+// and branch survive on disk. Restoring such an instance must park it as Paused so the
+// user can resume it. Returning an error instead is not an option: LoadInstances aborts on
+// the first failure, so one dead session would hide every other instance.
+// See https://github.com/smtg-ai/claude-squad/issues/216.
+func TestStartPausesInstanceWhenTmuxSessionNoLongerExists(t *testing.T) {
+	ptyFactory := &nullPtyFactory{t: t}
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") {
+				return fmt.Errorf("can't find session")
+			}
+			return nil
+		},
+	}
+
+	instance, err := NewInstance(InstanceOptions{Title: "revived", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	instance.SetTmuxSession(tmux.NewTmuxSessionWithDeps("revived", "claude", ptyFactory, cmdExec))
+
+	require.NoError(t, instance.Start(false), "a dead tmux session is recoverable, not a startup failure")
+	require.Equal(t, Paused, instance.Status)
+	require.True(t, instance.Started())
+	require.Zero(t, ptyFactory.calls, "should not attach to a session that does not exist")
+}
+
+// The happy path is unchanged: an instance whose session survived comes back Running.
+func TestStartRestoresInstanceWhenTmuxSessionSurvives(t *testing.T) {
+	ptyFactory := &nullPtyFactory{t: t}
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error { return nil },
+	}
+
+	instance, err := NewInstance(InstanceOptions{Title: "alive", Path: t.TempDir(), Program: "claude"})
+	require.NoError(t, err)
+	instance.SetTmuxSession(tmux.NewTmuxSessionWithDeps("alive", "claude", ptyFactory, cmdExec))
+
+	require.NoError(t, instance.Start(false))
+	require.Equal(t, Running, instance.Status)
+	require.Equal(t, 1, ptyFactory.calls)
+}

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -59,6 +59,10 @@ type TmuxSession struct {
 
 const TmuxPrefix = "claudesquad_"
 
+// ErrSessionNotFound is returned when the tmux session backing an instance is gone, which
+// happens whenever the tmux server dies (reboot, crash, `tmux kill-server`).
+var ErrSessionNotFound = errors.New("tmux session no longer exists")
+
 var whiteSpaceRegex = regexp.MustCompile(`\s+`)
 
 func toClaudeSquadTmuxName(str string) string {
@@ -181,6 +185,13 @@ func (t *TmuxSession) CheckAndHandleTrustPrompt() bool {
 
 // Restore attaches to an existing session and restores the window size
 func (t *TmuxSession) Restore() error {
+	// attach-session against a missing session still forks a process successfully, so the
+	// PTY start below would report no error while leaving us attached to nothing. Check
+	// first so callers can tell "session is gone" apart from "PTY failed".
+	if !t.DoesSessionExist() {
+		return ErrSessionNotFound
+	}
+
 	ptmx, err := t.ptyFactory.Start(exec.Command("tmux", "attach-session", "-t", t.sanitizedName))
 	if err != nil {
 		return fmt.Errorf("error opening PTY: %w", err)

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -86,3 +86,36 @@ func TestStartTmuxSession(t *testing.T) {
 	_, err = ptyFactory.files[1].Stat()
 	require.NoError(t, err)
 }
+
+// A tmux server that has gone away (reboot, crash, `tmux kill-server`) takes every session
+// with it. attach-session against a missing session still forks successfully, so Restore
+// has to check for the session itself or it reports success while attached to nothing.
+func TestRestoreReturnsErrSessionNotFoundWhenSessionIsGone(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error {
+			if strings.Contains(cmd.String(), "has-session") {
+				return fmt.Errorf("can't find session")
+			}
+			return nil
+		},
+	}
+
+	session := NewTmuxSessionWithDeps("gone", "program", ptyFactory, cmdExec)
+	err := session.Restore()
+
+	require.ErrorIs(t, err, ErrSessionNotFound)
+	require.Empty(t, ptyFactory.cmds, "should not have opened a PTY for a session that does not exist")
+}
+
+func TestRestoreAttachesWhenSessionExists(t *testing.T) {
+	ptyFactory := NewMockPtyFactory(t)
+	cmdExec := cmd_test.MockCmdExec{
+		RunFunc: func(cmd *exec.Cmd) error { return nil },
+	}
+
+	session := NewTmuxSessionWithDeps("alive", "program", ptyFactory, cmdExec)
+	require.NoError(t, session.Restore())
+	require.Len(t, ptyFactory.cmds, 1)
+	require.Contains(t, ptyFactory.cmds[0].String(), "attach-session")
+}


### PR DESCRIPTION
Fixes #216.

## The bug

When the tmux server goes away — reboot, crash, `tmux kill-server` — every session goes with it, but the instances in `state.json` are still recorded as `Running`. On the next start `cs` tries to attach to sessions that no longer exist.

The problem is that `tmux attach-session` against a missing session **forks successfully** and then exits 1 on its own. So `pty.Start` returns no error and `TmuxSession.Restore` reported success while attached to nothing:

```go
func (t *TmuxSession) Restore() error {
	ptmx, err := t.ptyFactory.Start(exec.Command("tmux", "attach-session", "-t", t.sanitizedName))
	if err != nil {   // only fires if the *fork* fails
		return fmt.Errorf("error opening PTY: %w", err)
	}
	...
```

The instance then sits there `Running` with every `capture-pane` against it failing, spamming the TUI and the log:

```
ERROR tmux.go:238: error capturing pane content in status monitor: error capturing pane content: exit status 1
ERROR app.go:987: error capturing pane content: exit status 1
```

The preview pane stays blank and there is no way to get the session back — `r` is gated on `Paused`, so the only exits are killing the instance or `cs reset`. Several reports in #216 match this shape ("happens when I come back to sessions after a few days"); other reports in that thread look like a different, new-session failure, which this PR does not touch.

## The fix

Three changes:

**1. `Restore` checks that the session exists** and returns a new `ErrSessionNotFound` sentinel when it does not, so callers can tell "session is gone" apart from "PTY failed".

**2. Restoring an instance whose session is gone parks it as `Paused`** instead of leaving it `Running`-but-broken. The worktree and branch are still on disk, so the existing `Resume` path rebuilds the session from the same `Program`.

Returning an error from `Start` here would be worse than useless: `Storage.LoadInstances` aborts on the first `FromInstanceData` failure, so a single dead session would hide *every* other instance.

**3. `Resume` no longer runs `gitWorktree.Setup` when the worktree is still valid on disk.** `setupFromExistingBranch` does `worktree remove -f` + `os.RemoveAll` before re-adding, which is correct after a normal `Pause` (the directory is already gone), but would throw away uncommitted work in an instance paused by the new recovery path above. This is the change that makes recovery non-destructive.

## Verification

Reproduced against a real `state.json` with five instances whose tmux server had died in a reboot, loading them through `Storage.LoadInstances` before and after:

```
before:  photos tagger  status=Running  previewErr=error capturing pane content: exit status 1
after:   photos tagger  status=Paused   previewErr=<nil>
```

All five then resumed from the TUI with `r` into working sessions, worktrees and uncommitted contents intact.

Four tests added — `Restore` returning `ErrSessionNotFound` vs. attaching normally, and `Start(false)` parking a dead-session instance as `Paused` vs. restoring a live one as `Running`. `gofmt`, `go vet` and the full suite are clean.
