### PR TITLE
fix(config): allow the config directory to be overridden so two instances stop clobbering each other

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,10 +15,26 @@ import (
 const (
 	ConfigFileName = "config.json"
 	defaultProgram = "claude"
+
+	// ConfigDirEnvVar overrides the configuration directory. Set it to run
+	// independent instances side by side -- one per repository, say -- each with
+	// its own config.json and state.json.
+	//
+	// Without it every instance shares $HOME/.claude-squad/state.json, and because
+	// SaveState writes the whole file without re-reading it, the last instance to
+	// save silently drops the other's sessions. Their worktrees and tmux sessions
+	// survive, so the instances stay alive but stop being listed.
+	ConfigDirEnvVar = "CLAUDE_SQUAD_DIR"
 )
 
-// GetConfigDir returns the path to the application's configuration directory
+// GetConfigDir returns the path to the application's configuration directory.
+//
+// $CLAUDE_SQUAD_DIR takes precedence when set and non-empty; otherwise the
+// directory is $HOME/.claude-squad as before, so existing installs are unaffected.
 func GetConfigDir() (string, error) {
+	if dir := strings.TrimSpace(os.Getenv(ConfigDirEnvVar)); dir != "" {
+		return dir, nil
+	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("failed to get config home directory: %w", err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -114,6 +114,11 @@ func TestDefaultConfig(t *testing.T) {
 
 func TestGetConfigDir(t *testing.T) {
 	t.Run("returns valid config directory", func(t *testing.T) {
+		// Explicitly cleared: the default path is only reached when the override
+		// is unset, and a developer with it exported would otherwise see this
+		// pass or fail depending on their shell.
+		t.Setenv(ConfigDirEnvVar, "")
+
 		configDir, err := GetConfigDir()
 
 		assert.NoError(t, err)
@@ -122,6 +127,48 @@ func TestGetConfigDir(t *testing.T) {
 
 		// Verify it's an absolute path
 		assert.True(t, filepath.IsAbs(configDir))
+	})
+
+	t.Run("honours CLAUDE_SQUAD_DIR when set", func(t *testing.T) {
+		want := t.TempDir()
+		t.Setenv(ConfigDirEnvVar, want)
+
+		configDir, err := GetConfigDir()
+
+		assert.NoError(t, err)
+		assert.Equal(t, want, configDir)
+	})
+
+	t.Run("two overrides yield independent state files", func(t *testing.T) {
+		// The point of the override: instance A and instance B must not write
+		// the same state.json. Without it both resolve to $HOME/.claude-squad
+		// and the last SaveState wins, dropping the other's sessions.
+		dirA, dirB := t.TempDir(), t.TempDir()
+
+		t.Setenv(ConfigDirEnvVar, dirA)
+		gotA, err := GetConfigDir()
+		require.NoError(t, err)
+
+		t.Setenv(ConfigDirEnvVar, dirB)
+		gotB, err := GetConfigDir()
+		require.NoError(t, err)
+
+		assert.NotEqual(t, gotA, gotB)
+		assert.Equal(t, dirA, gotA)
+		assert.Equal(t, dirB, gotB)
+	})
+
+	t.Run("blank or whitespace override falls back to the default", func(t *testing.T) {
+		for _, v := range []string{"", "   ", "\t"} {
+			t.Setenv(ConfigDirEnvVar, v)
+
+			configDir, err := GetConfigDir()
+
+			assert.NoError(t, err)
+			assert.True(t, strings.HasSuffix(configDir, ".claude-squad"),
+				"blank override %q must not produce an empty config dir", v)
+			assert.True(t, filepath.IsAbs(configDir))
+		}
 	})
 }
 


### PR DESCRIPTION

## What happens

`GetConfigDir()` (`config/config.go:21`) returns `$HOME/.claude-squad`
unconditionally, so every instance on a machine shares one `state.json`.
`SaveState` (`config/state.go:91`) writes the whole file without re-reading it,
so **the last instance to save silently drops the other's sessions.**

The dropped sessions do not stop. Their worktrees and tmux sessions are still
there and still running — they just vanish from the instance list, which makes
this read as a UI glitch rather than lost state.

## Measured

One machine, two instances, one per repository:

    worktrees under ~/.claude-squad/worktrees/    13
    entries in state.json                          9
    live tmux sessions not listed                  4

The four unlisted sessions have worktrees that claude-squad itself created, so
they were real instances, not hand-made tmux sessions.

## Reproduce

1. Two separate repos, e.g. `~/dev/repo-a` and `~/dev/repo-b`
2. Run one claude-squad instance in each, in separate terminals
3. Create a session in A, then create one in B
4. B's `SaveState` writes a list that never contained A's session

## Checked before adding a knob

- **no existing env var** — `os.Getenv` appears only for `SHELL`, plus `HOME`
  inside tests
- **no CLI flag** — `main.go` `rootCmd` has `--program`, `--autoyes`,
  hidden `--daemon`, and the `reset`/`debug`/`version` subcommands
- **no config.json key**
- **setting `HOME` is not a workaround** — it relocates every other tool's
  dotfiles, including the agent's own configuration

## The change

`$CLAUDE_SQUAD_DIR` takes precedence when set and non-empty. Unset, the path is
unchanged, so existing installs are unaffected.

## Tests

Four subtests on `TestGetConfigDir`: the override honoured; two overrides
yielding independent paths (the actual bug); blank and whitespace-only values
falling back to the default. The existing default-path test now clears the
variable explicitly, so it cannot pass or fail depending on the developer's
shell.

`go test ./...` green across all six packages.

## Prior art

Same class as shotgun-sh/shotgun#534's secondary issue: global session state
that should be scoped to the working directory.