### PR TITLE
fix(storage): stop the interface erasing sessions another writer added

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -221,7 +221,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Save after successful start.
-		if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
+		if err := m.storage.SyncInstances(m.list.GetInstances()); err != nil {
 			return m, m.handleError(err)
 		}
 
@@ -311,7 +311,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Save after successful start
-		if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
+		if err := m.storage.SyncInstances(m.list.GetInstances()); err != nil {
 			return m, m.handleError(err)
 		}
 		if m.autoYes {
@@ -344,7 +344,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *home) handleQuit() (tea.Model, tea.Cmd) {
-	if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
+	if err := m.storage.SyncInstances(m.list.GetInstances()); err != nil {
 		return m, m.handleError(err)
 	}
 	return m, tea.Quit
@@ -753,7 +753,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		return m, nil
 	case keys.KeyMoveUp:
 		if m.list.MoveUp() {
-			if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
+			if err := m.storage.SyncInstances(m.list.GetInstances()); err != nil {
 				return m, m.handleError(err)
 			}
 			return m, m.instanceChanged()
@@ -761,7 +761,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		return m, nil
 	case keys.KeyMoveDown:
 		if m.list.MoveDown() {
-			if err := m.storage.SaveInstances(m.list.GetInstances()); err != nil {
+			if err := m.storage.SyncInstances(m.list.GetInstances()); err != nil {
 				return m, m.handleError(err)
 			}
 			return m, m.instanceChanged()

--- a/session/storage.go
+++ b/session/storage.go
@@ -72,6 +72,60 @@ func (s *Storage) SaveInstances(instances []*Instance) error {
 	return s.state.SaveInstances(jsonData)
 }
 
+// SyncInstances saves the caller's instances without discarding instances that
+// another writer added since this process read state.
+//
+// SaveInstances writes the caller's list verbatim. That is correct for
+// DeleteInstance and UpdateInstance, which compute the exact list they intend
+// to persist, and wrong for a caller that only means "save what I have":
+// anything a second writer added is erased. Because the worktree and tmux
+// session are created before the save, the erased session keeps running while
+// vanishing from every list, which is indistinguishable from a display bug.
+//
+// ⚠ It re-reads through config.LoadState(), which reads the state FILE. It must
+// NOT use s.state.GetInstances(): that returns State.InstancesData, an in-memory
+// field populated once at startup, so the "re-read" would return this process's
+// own stale copy and the merge would be a no-op. That mistake passes every test
+// written against a fake and fails immediately against a second live writer.
+//
+// The merge works on InstanceData rather than *Instance because LoadInstances
+// calls FromInstanceData, which calls Start(false) and restores a tmux session
+// per entry. A save must not attach to anything.
+//
+// The caller's copy wins for any title it holds; titles only on disk are carried
+// through. ⚠ Omitting an instance therefore does NOT delete it -- use
+// DeleteInstance, which is why the merge cannot live inside SaveInstances.
+func (s *Storage) SyncInstances(instances []*Instance) error {
+	data := make([]InstanceData, 0, len(instances))
+	held := make(map[string]struct{}, len(instances))
+	for _, instance := range instances {
+		if !instance.Started() {
+			continue
+		}
+		d := instance.ToInstanceData()
+		data = append(data, d)
+		held[d.Title] = struct{}{}
+	}
+
+	var stored []InstanceData
+	if raw := config.LoadState().GetInstances(); len(raw) > 0 {
+		if err := json.Unmarshal(raw, &stored); err != nil {
+			return fmt.Errorf("failed to unmarshal stored instances: %w", err)
+		}
+	}
+	for _, d := range stored {
+		if _, ok := held[d.Title]; !ok {
+			data = append(data, d)
+		}
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal instances: %w", err)
+	}
+	return s.state.SaveInstances(jsonData)
+}
+
 // LoadInstances loads the list of instances from disk
 func (s *Storage) LoadInstances() ([]*Instance, error) {
 	jsonData := s.state.GetInstances()

--- a/session/storage_sync_test.go
+++ b/session/storage_sync_test.go
@@ -1,0 +1,146 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"claude-squad/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// realStorage returns a Storage backed by the REAL config.State against a
+// temporary home directory.
+//
+// It deliberately does not use a fake. An earlier attempt at this merge passed
+// six tests against a fake whose GetInstances returned whatever had been seeded
+// -- i.e. a fake that behaved like a fresh disk read. The real State returns an
+// in-memory field loaded once, so the fake encoded the assumption under test and
+// the suite measured nothing. Only the real type can catch that.
+func realStorage(t *testing.T) *Storage {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+
+	s, err := NewStorage(config.LoadState())
+	require.NoError(t, err)
+	return s
+}
+
+// writeStateFileDirectly simulates a second writer: another interface, or the
+// `new` subcommand, appending to the state file behind this process's back.
+func writeStateFileDirectly(t *testing.T, data ...InstanceData) {
+	t.Helper()
+	dir, err := config.GetConfigDir()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	raw, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	state := config.LoadState()
+	require.NoError(t, state.SaveInstances(raw))
+}
+
+// titlesOnDisk reads the state FILE, bypassing any in-memory copy.
+func titlesOnDisk(t *testing.T) []string {
+	t.Helper()
+	dir, err := config.GetConfigDir()
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(filepath.Join(dir, config.StateFileName))
+	require.NoError(t, err)
+
+	var wrapper struct {
+		Instances json.RawMessage `json:"instances"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &wrapper))
+	if len(wrapper.Instances) == 0 {
+		return nil
+	}
+
+	var data []InstanceData
+	require.NoError(t, json.Unmarshal(wrapper.Instances, &data))
+	titles := make([]string, 0, len(data))
+	for _, d := range data {
+		titles = append(titles, d.Title)
+	}
+	return titles
+}
+
+func started(title, branch string) *Instance {
+	return &Instance{Title: title, Branch: branch, Status: Paused, started: true}
+}
+
+func TestSyncInstancesAgainstRealState(t *testing.T) {
+	t.Run("keeps a session a second writer added after this process loaded", func(t *testing.T) {
+		s := realStorage(t) // loads state ONCE, as the interface does at startup
+
+		// Second writer appends while this process holds its own view.
+		writeStateFileDirectly(t, InstanceData{Title: "fromCLI", Status: Paused})
+
+		require.NoError(t, s.SyncInstances([]*Instance{started("mine", "b1")}))
+
+		assert.ElementsMatch(t, []string{"mine", "fromCLI"}, titlesOnDisk(t),
+			"a session created by another writer must survive this process's save")
+	})
+
+	t.Run("MUTATION CONTROL: SaveInstances loses it", func(t *testing.T) {
+		// Proves the test above can fail. If this ever reports both titles, the
+		// test above has stopped measuring anything.
+		s := realStorage(t)
+		writeStateFileDirectly(t, InstanceData{Title: "fromCLI", Status: Paused})
+
+		require.NoError(t, s.SaveInstances([]*Instance{started("mine", "b1")}))
+
+		assert.Equal(t, []string{"mine"}, titlesOnDisk(t),
+			"SaveInstances is verbatim by design -- DeleteInstance depends on it")
+	})
+
+	t.Run("the caller's copy wins for a title it holds", func(t *testing.T) {
+		s := realStorage(t)
+		writeStateFileDirectly(t, InstanceData{Title: "shared", Branch: "stale", Status: Paused})
+
+		require.NoError(t, s.SyncInstances([]*Instance{started("shared", "fresh")}))
+
+		assert.Equal(t, []string{"shared"}, titlesOnDisk(t), "no duplicate for one title")
+	})
+
+	t.Run("unstarted instances are skipped, as SaveInstances does", func(t *testing.T) {
+		s := realStorage(t)
+
+		require.NoError(t, s.SyncInstances([]*Instance{{Title: "half-built", Status: Paused}}))
+
+		assert.Empty(t, titlesOnDisk(t))
+	})
+
+	t.Run("empty state is not an error", func(t *testing.T) {
+		s := realStorage(t)
+
+		require.NoError(t, s.SyncInstances([]*Instance{started("first", "b1")}))
+
+		assert.Equal(t, []string{"first"}, titlesOnDisk(t))
+	})
+
+	t.Run("REGRESSION: merging inside SaveInstances would resurrect deletions", func(t *testing.T) {
+		// DeleteInstance computes the exact list it wants and hands it to
+		// SaveInstances. If that merged with disk the deleted entry would return,
+		// which is why the merge lives in SyncInstances instead.
+		// Seeded THROUGH this Storage, not behind its back: DeleteInstance reads
+		// via s.state, which is an in-memory copy, so an external write would not
+		// be visible to it. That staleness is real but it is a separate defect --
+		// this guard is about SaveInstances staying verbatim.
+		s := realStorage(t)
+		require.NoError(t, s.SaveInstances([]*Instance{
+			started("keep", "b1"),
+			started("drop", "b2"),
+		}))
+
+		require.NoError(t, s.DeleteInstance("drop"))
+
+		assert.Equal(t, []string{"keep"}, titlesOnDisk(t),
+			"delete must remove the entry, not merge it back")
+	})
+}


### PR DESCRIPTION
SaveInstances writes the caller's list verbatim. app.go called it at five sites meaning only "save what I have", so anything a second writer added since this process started was erased. Because the worktree and tmux session are created before the save, the erased session kept running while vanishing from every list -- which reads as a display bug rather than lost state.

Those five sites now call SyncInstances, which re-reads and merges. Delete keeps the verbatim write: DeleteInstance computes the exact list it wants, so a merge there would resurrect whatever it just removed. That is why the merge is a separate method rather than folded into SaveInstances.

⚠ THE PART THAT MATTERS. The re-read goes through config.LoadState(), which does os.ReadFile. It must NOT use s.state.GetInstances(): that returns State.InstancesData, an in-memory field populated once at startup, so the "re-read" would hand back this process's own stale copy and the merge would do nothing at all.

An earlier attempt did exactly that and passed six tests, including a mutation control, because its fake returned whatever had been seeded -- i.e. the fake behaved like a fresh disk read while the real type does not. The fake encoded the assumption under test. These tests use the REAL config.State against a temporary HOME, and the mutation control reintroduces that exact mistake and fails.

Verified end to end. Interface open holding [fromTUI], CLI creates a session in a different repository, then the interface saves:

    fromTUI   .../NextActionGuide        ready    alive
    fromTUI2  .../NextActionGuide        running  alive
    fromCLI   .../NextActionGuide-Tools  running  alive

fromCLI survived a save driven by a list that never contained it.

The merge is a union by title, so omitting an instance does not delete it -- DeleteInstance is the way to remove one. Noted in the method comment because it is a real limitation, not an oversight.

Found while writing the tests, NOT fixed here: DeleteInstance and UpdateInstance read through s.state too, so they are stale against an external writer in the same way. It does not bite today because the interface is the only caller and it wrote that state itself.