### PR TITLE
fix: detect Ctrl+Q detach reliably

### DIFF
--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -266,6 +266,55 @@ func (t *TmuxSession) HasUpdated() (updated bool, hasPrompt bool) {
 	return false, hasPrompt
 }
 
+// ctrlQModifyOtherKeys is the xterm modifyOtherKeys-encoded Ctrl+Q sequence:
+// CSI 27 ; <modifier=5 (ctrl)> ; <key=113 (q)> ~.
+var ctrlQModifyOtherKeys = []byte{0x1b, '[', '2', '7', ';', '5', ';', '1', '1', '3', '~'}
+
+// ctrlQModifyOtherKeysShift handles Ctrl+Shift+Q (capital Q = 81).
+var ctrlQModifyOtherKeysShift = []byte{0x1b, '[', '2', '7', ';', '6', ';', '8', '1', '~'}
+
+// scanForDetach inspects a chunk read from stdin for a Ctrl+Q detach signal.
+// Returns the number of preceding bytes to forward to the inner session and
+// detach=true if found. Otherwise returns (len(buf), false) so the caller
+// forwards everything.
+//
+// Ctrl+Q can arrive in two forms:
+//
+//   - Single byte 0x11, the normal control-character encoding.
+//
+//   - The 11-byte sequence "\x1b[27;5;113~", the xterm modifyOtherKeys
+//     encoding. Terminals emit this once they have been put into
+//     modifyOtherKeys mode. That happens outside our control: with tmux's
+//     "extended-keys" option enabled, an application running inside the pane
+//     (Claude Code does this) requests modifyOtherKeys with CSI > 4 ; 2 m, and
+//     tmux propagates the request outward to the real terminal. From then on
+//     every Ctrl+Q reaches us as 11 bytes and never as 0x11.
+//
+// os.Stdin.Read also returns multiple bytes per call routinely — terminal
+// query replies, mouse-tracking sequences (sessions run with "mouse on"), and
+// keystrokes co-buffered with either — so we scan the whole chunk rather than
+// checking for a lone byte.
+//
+// Known limitation: a bracketed paste whose contents include a literal 0x11
+// will detach. This is benign (press Enter to reattach) and not a regression:
+// forwarding that byte to tmux instead makes it swallow the byte as XON, so
+// the paste is corrupted either way.
+func scanForDetach(buf []byte) (forwardLen int, detach bool) {
+	// Take the earliest match across all encodings, so everything typed before
+	// the detach key still reaches the session no matter which form arrived.
+	forwardLen = len(buf)
+	for _, idx := range []int{
+		bytes.IndexByte(buf, 17),
+		bytes.Index(buf, ctrlQModifyOtherKeys),
+		bytes.Index(buf, ctrlQModifyOtherKeysShift),
+	} {
+		if idx >= 0 && idx < forwardLen {
+			forwardLen, detach = idx, true
+		}
+	}
+	return forwardLen, detach
+}
+
 func (t *TmuxSession) Attach() (chan struct{}, error) {
 	t.attachCh = make(chan struct{})
 
@@ -302,8 +351,10 @@ func (t *TmuxSession) Attach() (chan struct{}, error) {
 			close(timeoutCh)
 		}()
 
-		// Read input from stdin and check for Ctrl+q
-		buf := make([]byte, 32)
+		// Read input from stdin and check for Ctrl+q. The buffer is large
+		// enough that a multi-byte key encoding cannot straddle two reads,
+		// which would hide it from scanForDetach.
+		buf := make([]byte, 4096)
 		for {
 			nr, err := os.Stdin.Read(buf)
 			if err != nil {
@@ -327,15 +378,14 @@ func (t *TmuxSession) Attach() (chan struct{}, error) {
 				continue
 			}
 
-			// Check for Ctrl+q (ASCII 17)
-			if nr == 1 && buf[0] == 17 {
-				// Detach from the session
+			forwardLen, detach := scanForDetach(buf[:nr])
+			if forwardLen > 0 {
+				_, _ = t.ptmx.Write(buf[:forwardLen])
+			}
+			if detach {
 				t.Detach()
 				return
 			}
-
-			// Forward other input to tmux
-			_, _ = t.ptmx.Write(buf[:nr])
 		}
 	}()
 

--- a/session/tmux/tmux_test.go
+++ b/session/tmux/tmux_test.go
@@ -41,6 +41,58 @@ func NewMockPtyFactory(t *testing.T) *MockPtyFactory {
 	}
 }
 
+func TestScanForDetach(t *testing.T) {
+	modifyOtherKeysCtrlQ := []byte{0x1b, '[', '2', '7', ';', '5', ';', '1', '1', '3', '~'}
+	modifyOtherKeysCtrlShiftQ := []byte{0x1b, '[', '2', '7', ';', '6', ';', '8', '1', '~'}
+	// Sequences that look like the detach key but are not, plus a mouse-report
+	// burst of the kind that routinely arrives co-buffered with a keystroke.
+	ctrlP := []byte("\x1b[27;5;112~")
+	shiftQ := []byte("\x1b[27;2;81~")
+	truncated := []byte("\x1b[27;5;11")
+	mouseBurst := []byte("\x1b[<64;10;5M")
+
+	cases := []struct {
+		name        string
+		buf         []byte
+		wantForward int
+		wantDetach  bool
+	}{
+		{"empty buffer", []byte{}, 0, false},
+		{"single non-ctrl-q byte", []byte{'a'}, 1, false},
+		{"multi-byte without ctrl-q", []byte("hello"), 5, false},
+		{"single ctrl-q byte", []byte{0x11}, 0, true},
+		{"ctrl-q at start with trailing bytes", []byte{0x11, 'a', 'b'}, 0, true},
+		{"ctrl-q in the middle", []byte{'a', 0x11, 'b'}, 1, true},
+		{"ctrl-q after mouse-tracking escape", []byte{0x1b, '[', 'M', ' ', '!', '!', 0x11}, 6, true},
+		{"modifyOtherKeys ctrl-q alone", modifyOtherKeysCtrlQ, 0, true},
+		{"modifyOtherKeys ctrl-q preceded by other bytes", append([]byte{'a', 'b'}, modifyOtherKeysCtrlQ...), 2, true},
+		{"modifyOtherKeys ctrl-shift-q", modifyOtherKeysCtrlShiftQ, 0, true},
+		{"unrelated CSI sequence is not ctrl-q", []byte{0x1b, '[', 'A'}, 3, false},
+		{"modifyOtherKeys ctrl-p is not ctrl-q", ctrlP, len(ctrlP), false},
+		{"modifyOtherKeys shift-q without ctrl is not ctrl-q", shiftQ, len(shiftQ), false},
+		{"truncated modifyOtherKeys sequence is not ctrl-q", truncated, len(truncated), false},
+		{
+			"ctrl-q after an SGR mouse burst",
+			append(append([]byte{}, mouseBurst...), 0x11),
+			len(mouseBurst),
+			true,
+		},
+		{
+			"earliest encoding wins when both forms are present",
+			append(append([]byte{}, modifyOtherKeysCtrlQ...), 'a', 0x11),
+			0,
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotForward, gotDetach := scanForDetach(tc.buf)
+			require.Equal(t, tc.wantForward, gotForward)
+			require.Equal(t, tc.wantDetach, gotDetach)
+		})
+	}
+}
+
 func TestSanitizeName(t *testing.T) {
 	session := NewTmuxSession("asdf", "program")
 	require.Equal(t, TmuxPrefix+"asdf", session.sanitizedName)


### PR DESCRIPTION
## Symptom

Pressing <kbd>Ctrl</kbd>+<kbd>Q</kbd> to detach from an attached session
intermittently does nothing — and on some setups never works at all — leaving
you stuck inside the session with no way back to the list. Likely the same
underlying bug as #57.

## Root causes

Both are in the stdin reader in `TmuxSession.Attach` (`session/tmux/tmux.go`).

### 1. The detach check assumed a one-byte read

```go
if nr == 1 && buf[0] == 17 {
```

`os.Stdin.Read` returns multiple bytes per call routinely: terminal query
replies, mouse-tracking sequences (sessions are created with `mouse on`), and
keystrokes co-buffered with either. Whenever `0x11` arrived alongside anything
else, the check was skipped and the byte fell through to
`t.ptmx.Write(buf[:nr])` — where tmux swallows it as XON. The keypress vanishes
silently.

That multi-byte reads are the norm is visible in Claude Squad's own log, from
the existing `nuked first stdin` line in this same loop:

```
nuked first stdin: ^[[?64;1;2;4;6;17;18;21;22;52c   <- 30 bytes in ONE read
nuked first stdin: ^[[8;45;156t^[[4;802;1119t       <- two complete replies in ONE read
nuked first stdin: ^[P>|iTerm2 3.6.11^[\^[]10;rgb:86be  <- fills the 32-byte buffer...
nuked first stdin: /940d/9624^[\^[]11;rgb:0dc8/2a5e/3   <- ...and continues
nuked first stdin: 4ff^[\                               <- ...across three reads
```

### 2. Ctrl+Q is not always byte `0x11`

Once the terminal has been put into xterm `modifyOtherKeys` mode, it encodes
Ctrl+Q as the 11-byte sequence `ESC [ 27 ; 5 ; 113 ~` and never as `0x11`.

This happens outside Claude Squad's control. With tmux's `extended-keys` option
enabled, an application running *inside* the pane — Claude Code requests
`CSI > 4 ; 2 m` — causes tmux to propagate that request *outward* to the real
terminal. From then on every Ctrl+Q reaches us in the long form, so the detach
check never fires and the user is permanently stuck.

## The fix

- Scan the whole read chunk for a detach key instead of testing a single byte.
  Bytes preceding it are still forwarded to the session; then we detach.
- Recognize the `modifyOtherKeys` encoding (and Ctrl+Shift+Q, for symmetry).
- Grow the read buffer from 32 to 4096 bytes, so a multi-byte key encoding
  cannot straddle two reads and hide from the scanner. As the log above shows,
  the 32-byte buffer was filling completely in practice.

The detection is extracted into a pure `scanForDetach(buf) (forwardLen, detach)`
helper with table-driven unit tests, covering both encodings, co-buffered
arrivals, and near-miss sequences that must *not* match (`ESC[27;5;112~` for
Ctrl+P, `ESC[27;2;81~` for plain Shift+Q, a truncated sequence).

One side effect worth naming: growing the buffer slightly widens what the
existing 50 ms "nuke the first bytes of stdin" heuristic can discard in one go.
That heuristic is left untouched here as orthogonal.

### Known limitation

A bracketed paste whose contents include a literal `0x11` will now detach. This
is benign and instantly recoverable (press Enter to reattach), and it is not a
regression: the previous behavior forwarded that byte to tmux, which dropped it
as XON, so such a paste was corrupted either way. Documented in a comment above
`scanForDetach`. Happy to add bracketed-paste suppression if you'd prefer it.

## Reproducing

**Encoding bug (root cause 2).** Add to `~/.tmux.conf`:

```tmux
set -s extended-keys always
set -as terminal-features 'tmux-256color:extkeys'
```

Then `tmux kill-server`, run `cs` in a git repo, create a session, press Enter
to attach, and press Ctrl+Q. On `main` nothing happens; on this branch you
detach immediately.

Confirm the encoding independently, without Claude Squad:

```sh
printf '\e[>4;2m'; cat -v     # press Ctrl+Q -> prints ^[[27;5;113~ instead of ^Q
printf '\e[>4m'               # reset
```

**Read-length bug (root cause 1), no config needed.** Attach to a session, then
scroll the mouse wheel rapidly while pressing Ctrl+Q. On `main` this
intermittently fails to detach; on this branch it always detaches.

## Testing

- `gofmt -l .` clean; `go build ./...`, `go vet ./...` and `go test ./...` all
  pass.
- New `TestScanForDetach` covers 16 cases, including the negative ones above.
- The buffer scan and the `modifyOtherKeys` detection have been running in my
  fork for several months of daily use. The buffer-size increase is new in this
  PR; broader manual verification is in progress and I'll report back here. If
  you'd rather land the detection fix without the buffer change, I'm happy to
  split it out.
- The Terminal tab attach path (`ui/tabbed_window.go` `AttachTerminal`) shares
  `TmuxSession.Attach()`, so it is covered by the same fix.

## Related, out of scope

While a session is attached, Bubble Tea's input reader and this loop both read
`os.Stdin` concurrently. The impact is bounded (roughly one swallowed chunk per
attach) and it does not cause the bug above, but it is real. Filed separately as
#325 rather than bundled here.
