### PR TITLE
Show each session's GitHub CI verdict in the instance list

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -5,6 +5,7 @@ import (
 	"claude-squad/keys"
 	"claude-squad/log"
 	"claude-squad/session"
+	"claude-squad/session/ci"
 	"claude-squad/session/git"
 	"claude-squad/ui"
 	"claude-squad/ui/overlay"
@@ -189,7 +190,7 @@ func (m *home) Init() tea.Cmd {
 			time.Sleep(100 * time.Millisecond)
 			return previewTickMsg{}
 		},
-		tickUpdateMetadataCmd(m.snapshotActiveInstances(), m.list.GetSelectedInstance()),
+		tickUpdateMetadataCmd(m.snapshotActiveInstances(), m.list.GetSelectedInstance(), m.appConfig.CIStatusEnabled()),
 	)
 }
 
@@ -256,8 +257,9 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				r.instance.SetDiffStats(r.diffStats)
 			}
+			r.instance.SetCIStatus(r.ciStatus)
 		}
-		return m, tickUpdateMetadataCmd(m.snapshotActiveInstances(), m.list.GetSelectedInstance())
+		return m, tickUpdateMetadataCmd(m.snapshotActiveInstances(), m.list.GetSelectedInstance(), m.appConfig.CIStatusEnabled())
 	case tea.MouseMsg:
 		// Handle mouse wheel events for scrolling the diff/preview pane
 		if msg.Action == tea.MouseActionPress {
@@ -907,6 +909,7 @@ type instanceMetaResult struct {
 	updated   bool
 	hasPrompt bool
 	diffStats *git.DiffStats
+	ciStatus  ci.Status
 }
 
 // metadataUpdateDoneMsg is sent when the background metadata update completes.
@@ -951,7 +954,7 @@ func (m *home) snapshotActiveInstances() []*session.Instance {
 // Only the selected instance gets a full diff (with Content); the rest get a
 // lightweight numstat-only summary. This keeps per-instance memory bounded
 // since the diff pane only ever renders the selected one.
-func tickUpdateMetadataCmd(active []*session.Instance, selected *session.Instance) tea.Cmd {
+func tickUpdateMetadataCmd(active []*session.Instance, selected *session.Instance, ciEnabled bool) tea.Cmd {
 	return func() tea.Msg {
 		time.Sleep(500 * time.Millisecond)
 
@@ -972,6 +975,9 @@ func tickUpdateMetadataCmd(active []*session.Instance, selected *session.Instanc
 					r.diffStats = instance.ComputeDiff()
 				} else {
 					r.diffStats = instance.ComputeDiffNumstat()
+				}
+				if ciEnabled {
+					r.ciStatus = ciStatusFor(instance)
 				}
 			}(idx, inst)
 		}
@@ -1072,4 +1078,18 @@ func (m *home) View() string {
 	}
 
 	return mainView
+}
+
+// ciStatusFor returns the cached CI verdict for an instance's branch. The lookup
+// is non-blocking by contract (see ci.Get) because it runs inside the same
+// metadata tick as the git diffs, which only re-schedules once every goroutine
+// has finished.
+func ciStatusFor(instance *session.Instance) ci.Status {
+	worktree, err := instance.GetGitWorktree()
+	if err != nil {
+		return ci.Status{}
+	}
+	// The recorded branch is only the fallback: ci resolves the worktree's actual
+	// HEAD, so a session whose branch was renamed or switched still finds its PR.
+	return ci.Get(worktree.GetRepoPath(), worktree.GetWorktreePath(), instance.Branch)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,16 @@ type Config struct {
 	BranchPrefix string `json:"branch_prefix"`
 	// Profiles is a list of named program profiles.
 	Profiles []Profile `json:"profiles,omitempty"`
+	// GitHubCIStatus controls the CI status badge shown next to each branch in
+	// the instance list. Nil means enabled: the badge is opt-out, and every config
+	// written before the feature existed has no such key, so nil must not read as
+	// false or the feature would be invisible on upgrade.
+	GitHubCIStatus *bool `json:"github_ci_status,omitempty"`
+}
+
+// CIStatusEnabled reports whether the GitHub CI status badge should be shown.
+func (c *Config) CIStatusEnabled() bool {
+	return c.GitHubCIStatus == nil || *c.GitHubCIStatus
 }
 
 // GetProgram returns the program to run. If Profiles is non-empty and
@@ -93,6 +103,7 @@ func DefaultConfig() *Config {
 		DefaultProgram:     program,
 		AutoYes:            false,
 		DaemonPollInterval: 1000,
+		GitHubCIStatus:     boolPtr(true),
 		BranchPrefix: func() string {
 			user, err := user.Current()
 			if err != nil || user == nil || user.Username == "" {
@@ -103,6 +114,8 @@ func DefaultConfig() *Config {
 		}(),
 	}
 }
+
+func boolPtr(b bool) *bool { return &b }
 
 // GetClaudeCommand attempts to find the "claude" command in the user's shell
 // It checks in the following order:

--- a/session/ci/ci.go
+++ b/session/ci/ci.go
@@ -1,0 +1,313 @@
+// Package ci reports the CI verdict for a session's branch, so the instance
+// list can show whether that branch's pull request is passing without leaving
+// the TUI.
+//
+// Everything here is best-effort by design: cs is useful without it, so a
+// missing or unauthenticated gh CLI, a branch with no pull request, or a failing
+// lookup all degrade to "no badge" rather than an error the user has to dismiss.
+package ci
+
+import (
+	"claude-squad/log"
+	"claude-squad/session/git"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// State is the overall verdict for a branch's CI checks.
+type State int
+
+const (
+	// StateUnknown means no verdict is available yet: no lookup has completed,
+	// gh is unavailable, or the pull request reported no classifiable checks.
+	StateUnknown State = iota
+	// StateNoPR means the branch has no open pull request.
+	StateNoPR
+	// StatePending means at least one check is queued or running, and none failed.
+	StatePending
+	// StateFailure means at least one check concluded in failure.
+	StateFailure
+	// StateSuccess means every check that reached a conclusion passed.
+	StateSuccess
+	// StateMerged means the pull request was merged. Checked before the individual
+	// checks, since a merged PR's checks are all green and would otherwise be
+	// indistinguishable from an open branch that is merely passing.
+	StateMerged
+	// StateClosed means the pull request was closed without being merged.
+	StateClosed
+)
+
+// Status is the CI verdict for one branch, plus the counts it was derived from.
+type Status struct {
+	State    State
+	PRNumber int
+	Passed   int
+	Failed   int
+	Pending  int
+	// FetchedAt is when the most recent lookup attempt completed. The zero value
+	// means no attempt has completed yet.
+	FetchedAt time.Time
+}
+
+const (
+	// ttl is how long a verdict is served before a refresh is triggered. Chosen
+	// to be far slower than the 500ms metadata tick that reads it: a GitHub round
+	// trip per instance per tick would be both rate-limit-hostile and pointless,
+	// since a workflow run takes minutes.
+	ttl = 30 * time.Second
+	// fetchTimeout bounds a single gh invocation so a hung network call cannot
+	// pin a cache entry in the "fetching" state forever.
+	fetchTimeout = 10 * time.Second
+)
+
+type entry struct {
+	status Status
+	// fetching guards against a second refresh being launched for a branch whose
+	// first one is still in flight — the reader runs every 500ms and a fetch
+	// takes ~1s, so without this every stale entry would spawn a pile of them.
+	fetching bool
+}
+
+var (
+	mu     sync.Mutex
+	cache  = make(map[string]entry)
+	ghPath string
+	// disabled latches once we learn gh cannot answer at all (absent, or not
+	// authenticated). Without it a broken auth setup logs a warning per instance
+	// every ttl, forever.
+	disabled bool
+	lookOnce sync.Once
+)
+
+// Get returns the last known CI status for a session's worktree, triggering a
+// background refresh when the cached verdict is older than ttl.
+//
+// Keyed on the worktree rather than a branch name, because the branch is resolved
+// at refresh time from the worktree's HEAD (see refresh): a session that switched
+// or renamed its branch must not keep reporting the old one's verdict, and it must
+// not need a second cache entry to stop doing so.
+//
+// It never blocks on the network or on git. The caller is the UI's metadata tick,
+// which also computes git diffs and only re-schedules once complete, so a slow gh
+// call here would directly stall diff-stat updates. The first call for a worktree
+// therefore returns the zero Status and the badge appears a tick or two later.
+func Get(repoPath, worktreePath, fallbackBranch string) Status {
+	if repoPath == "" || worktreePath == "" || !available() {
+		return Status{}
+	}
+
+	key := repoPath + "\x00" + worktreePath
+
+	mu.Lock()
+	defer mu.Unlock()
+	e := cache[key]
+	if time.Since(e.status.FetchedAt) > ttl && !e.fetching {
+		e.fetching = true
+		cache[key] = e
+		go refresh(key, repoPath, worktreePath, fallbackBranch)
+	}
+	return e.status
+}
+
+// refresh resolves the worktree's current branch and performs one lookup.
+//
+// The branch comes from HEAD rather than from the name the session was created
+// with, so that renaming the branch or checking out another one inside the
+// worktree is reflected. The recorded name is the fallback for a detached HEAD or
+// a worktree that has gone away.
+func refresh(key, repoPath, worktreePath, fallbackBranch string) {
+	branch, err := git.CurrentBranch(worktreePath)
+	if err != nil || branch == "" {
+		branch = fallbackBranch
+	}
+
+	var status Status
+	if branch == "" {
+		err = errors.New("no branch to look up")
+	} else {
+		status, err = fetch(repoPath, branch)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	e := cache[key]
+	e.fetching = false
+	if err != nil {
+		// Keep whatever verdict we had rather than blanking the badge on a
+		// transient failure, but stamp the attempt so the next retry waits a
+		// full ttl instead of firing on the next tick.
+		e.status.FetchedAt = time.Now()
+		cache[key] = e
+		log.WarningLog.Printf("could not fetch CI status for branch %q: %v", branch, err)
+		return
+	}
+	e.status = status
+	cache[key] = e
+}
+
+// rollupEntry is the subset of a statusCheckRollup element that carries an
+// outcome. A CheckRun (GitHub Actions and most apps) reports `conclusion` once
+// finished and `status` while running; a legacy StatusContext — some deploy and
+// coverage bots still post these — reports only `state`.
+type rollupEntry struct {
+	Conclusion string `json:"conclusion"`
+	Status     string `json:"status"`
+	State      string `json:"state"`
+}
+
+type prView struct {
+	Number            int           `json:"number"`
+	State             string        `json:"state"`
+	StatusCheckRollup []rollupEntry `json:"statusCheckRollup"`
+}
+
+// fetch runs gh in repoPath and classifies the result.
+func fetch(repoPath, branch string) (Status, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, ghPath, "pr", "view", branch, "--json", "number,state,statusCheckRollup")
+	// Run inside the repo so gh resolves the remote itself; this also means a
+	// fork or a non-github remote simply yields an error we swallow.
+	cmd.Dir = repoPath
+
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := stderrOf(err)
+		// gh exits non-zero for a branch with no pull request. That is a verdict,
+		// not a failure — and the common case for a session whose work is not
+		// pushed yet, so it must not be logged as an error every ttl.
+		if strings.Contains(stderr, "no pull requests found") {
+			return Status{State: StateNoPR, FetchedAt: time.Now()}, nil
+		}
+		// An auth problem is not per-branch and will not fix itself; stop asking.
+		if strings.Contains(stderr, "gh auth login") {
+			disable("gh is not authenticated")
+			return Status{}, errors.New("gh is not authenticated")
+		}
+		return Status{}, fmt.Errorf("gh pr view: %w: %s", err, strings.TrimSpace(stderr))
+	}
+
+	var view prView
+	if err := json.Unmarshal(out, &view); err != nil {
+		return Status{}, fmt.Errorf("parsing gh output: %w", err)
+	}
+
+	if terminal := terminalState(view.State); terminal != StateUnknown {
+		return Status{State: terminal, PRNumber: view.Number, FetchedAt: time.Now()}, nil
+	}
+
+	status := classify(view.StatusCheckRollup)
+	status.PRNumber = view.Number
+	status.FetchedAt = time.Now()
+	return status, nil
+}
+
+// terminalState maps a pull request's own state to a verdict, for the states where
+// the PR is the answer and its checks are not.
+//
+// Every check on a merged PR is green, so letting classify decide would render a
+// merged branch identically to an open one that is simply passing -- and a
+// closed-unmerged PR would likewise show a green tick for abandoned work. Returns
+// StateUnknown for an open PR, meaning "let the checks decide".
+func terminalState(prState string) State {
+	switch strings.ToUpper(prState) {
+	case "MERGED":
+		return StateMerged
+	case "CLOSED":
+		return StateClosed
+	default:
+		return StateUnknown
+	}
+}
+
+// classify reduces a status check rollup to a single verdict.
+//
+// SKIPPED and CANCELLED are ignored rather than counted as failures. A cancelled
+// run is nearly always one superseded by a newer push to the same branch, and
+// skipped jobs are the normal, healthy result of path filters — counting either
+// as red would leave most branches permanently showing a failure.
+func classify(entries []rollupEntry) Status {
+	var s Status
+	for _, e := range entries {
+		switch outcomeOf(e) {
+		case "SUCCESS", "NEUTRAL":
+			s.Passed++
+		case "FAILURE", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED", "ERROR":
+			s.Failed++
+		case "SKIPPED", "CANCELLED", "STALE", "":
+			// Carries no verdict — see the docblock.
+		default:
+			// QUEUED, IN_PROGRESS, PENDING, WAITING, REQUESTED, EXPECTED.
+			s.Pending++
+		}
+	}
+
+	// Deliberately ordered worst-first: one red check matters even while others
+	// are still running, which is the whole point of glancing at the badge.
+	switch {
+	case s.Failed > 0:
+		s.State = StateFailure
+	case s.Pending > 0:
+		s.State = StatePending
+	case s.Passed > 0:
+		s.State = StateSuccess
+	default:
+		s.State = StateUnknown
+	}
+	return s
+}
+
+// outcomeOf picks whichever field carries this entry's outcome.
+func outcomeOf(e rollupEntry) string {
+	if e.Conclusion != "" {
+		return strings.ToUpper(e.Conclusion)
+	}
+	if e.Status != "" {
+		return strings.ToUpper(e.Status)
+	}
+	return strings.ToUpper(e.State)
+}
+
+// available reports whether gh can be consulted. The PATH lookup happens once.
+func available() bool {
+	lookOnce.Do(func() {
+		path, err := exec.LookPath("gh")
+		if err != nil {
+			disable("gh CLI not found on PATH")
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		ghPath = path
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	return !disabled && ghPath != ""
+}
+
+// disable latches the feature off for the rest of the process, logging why once.
+func disable(reason string) {
+	mu.Lock()
+	defer mu.Unlock()
+	if disabled {
+		return
+	}
+	disabled = true
+	log.WarningLog.Printf("GitHub CI status badges disabled: %s", reason)
+}
+
+func stderrOf(err error) string {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return string(exitErr.Stderr)
+	}
+	return err.Error()
+}

--- a/session/ci/ci_test.go
+++ b/session/ci/ci_test.go
@@ -1,0 +1,166 @@
+package ci
+
+import "testing"
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []rollupEntry
+		want    State
+		passed  int
+		failed  int
+		pending int
+	}{
+		{
+			name:    "empty rollup has no verdict",
+			entries: nil,
+			want:    StateUnknown,
+		},
+		{
+			name: "all conclusions passed",
+			entries: []rollupEntry{
+				{Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Status: "COMPLETED", Conclusion: "NEUTRAL"},
+			},
+			want:   StateSuccess,
+			passed: 2,
+		},
+		{
+			// The reason the switch is ordered worst-first: a red check is the
+			// thing the badge exists to surface, even mid-run.
+			name: "a failure outranks checks still running",
+			entries: []rollupEntry{
+				{Status: "COMPLETED", Conclusion: "FAILURE"},
+				{Status: "IN_PROGRESS"},
+				{Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			want:    StateFailure,
+			passed:  1,
+			failed:  1,
+			pending: 1,
+		},
+		{
+			name: "pending outranks success",
+			entries: []rollupEntry{
+				{Status: "QUEUED"},
+				{Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			want:    StatePending,
+			passed:  1,
+			pending: 1,
+		},
+		{
+			// Path-filtered jobs and superseded runs are the normal case on a
+			// healthy branch; counting them red would leave most branches red.
+			name: "skipped and cancelled are ignored, not failures",
+			entries: []rollupEntry{
+				{Status: "COMPLETED", Conclusion: "SKIPPED"},
+				{Status: "COMPLETED", Conclusion: "CANCELLED"},
+				{Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			want:   StateSuccess,
+			passed: 1,
+		},
+		{
+			name: "a rollup of nothing but skips has no verdict",
+			entries: []rollupEntry{
+				{Status: "COMPLETED", Conclusion: "SKIPPED"},
+				{Status: "COMPLETED", Conclusion: "CANCELLED"},
+			},
+			want: StateUnknown,
+		},
+		{
+			name: "timed out and action required count as failures",
+			entries: []rollupEntry{
+				{Status: "COMPLETED", Conclusion: "TIMED_OUT"},
+				{Status: "COMPLETED", Conclusion: "ACTION_REQUIRED"},
+			},
+			want:   StateFailure,
+			failed: 2,
+		},
+		{
+			// Legacy StatusContext entries carry neither conclusion nor status.
+			name: "legacy status contexts are read from state",
+			entries: []rollupEntry{
+				{State: "FAILURE"},
+				{State: "SUCCESS"},
+			},
+			want:   StateFailure,
+			passed: 1,
+			failed: 1,
+		},
+		{
+			name: "lowercase outcomes are normalized",
+			entries: []rollupEntry{
+				{Conclusion: "success"},
+			},
+			want:   StateSuccess,
+			passed: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classify(tt.entries)
+			if got.State != tt.want {
+				t.Errorf("State = %v, want %v", got.State, tt.want)
+			}
+			if got.Passed != tt.passed {
+				t.Errorf("Passed = %d, want %d", got.Passed, tt.passed)
+			}
+			if got.Failed != tt.failed {
+				t.Errorf("Failed = %d, want %d", got.Failed, tt.failed)
+			}
+			if got.Pending != tt.pending {
+				t.Errorf("Pending = %d, want %d", got.Pending, tt.pending)
+			}
+		})
+	}
+}
+
+// A CheckRun reports `status` while running and `conclusion` once done; the
+// conclusion must win, or a finished check reads as still pending.
+func TestOutcomeOfPrefersConclusion(t *testing.T) {
+	got := outcomeOf(rollupEntry{Status: "COMPLETED", Conclusion: "FAILURE", State: "SUCCESS"})
+	if got != "FAILURE" {
+		t.Errorf("outcomeOf = %q, want FAILURE", got)
+	}
+
+	got = outcomeOf(rollupEntry{Status: "IN_PROGRESS", State: "SUCCESS"})
+	if got != "IN_PROGRESS" {
+		t.Errorf("outcomeOf = %q, want IN_PROGRESS", got)
+	}
+}
+
+// Get must answer instantly from cache; a network round trip on the 500ms
+// metadata tick would stall the diff stats computed alongside it.
+func TestGetIsNonBlockingAndSkipsBlankInput(t *testing.T) {
+	if s := Get("", "/worktree", "branch"); s.State != StateUnknown {
+		t.Errorf("blank repo path: State = %v, want StateUnknown", s.State)
+	}
+	if s := Get("/repo", "", "branch"); s.State != StateUnknown {
+		t.Errorf("blank worktree path: State = %v, want StateUnknown", s.State)
+	}
+}
+
+// A merged PR's checks are all green, so without this the row would look exactly
+// like an open branch that is passing -- and an abandoned PR would too.
+func TestTerminalState(t *testing.T) {
+	tests := []struct {
+		prState string
+		want    State
+	}{
+		{"MERGED", StateMerged},
+		{"merged", StateMerged},
+		{"CLOSED", StateClosed},
+		{"closed", StateClosed},
+		{"OPEN", StateUnknown},
+		{"", StateUnknown},
+	}
+
+	for _, tt := range tests {
+		if got := terminalState(tt.prState); got != tt.want {
+			t.Errorf("terminalState(%q) = %v, want %v", tt.prState, got, tt.want)
+		}
+	}
+}

--- a/session/git/util.go
+++ b/session/git/util.go
@@ -54,6 +54,25 @@ func IsGitRepo(path string) bool {
 	return cmd.Run() == nil
 }
 
+// CurrentBranch returns the branch checked out at the given path. This can differ
+// from the branch a session recorded when it was created: renaming the branch, or
+// checking out a different one, from inside the worktree is common, and the
+// recorded name then refers to something that may not exist any more.
+//
+// Returns an error on a detached HEAD, where there is no branch to name.
+func CurrentBranch(path string) (string, error) {
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to read current branch at %s: %w", path, err)
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch == "" || branch == "HEAD" {
+		return "", fmt.Errorf("detached HEAD at %s", path)
+	}
+	return branch, nil
+}
+
 func findGitRepoRoot(path string) (string, error) {
 	cmd := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel")
 	out, err := cmd.Output()

--- a/session/instance.go
+++ b/session/instance.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"claude-squad/log"
+	"claude-squad/session/ci"
 	"claude-squad/session/git"
 	"claude-squad/session/tmux"
 	"errors"
@@ -55,6 +56,11 @@ type Instance struct {
 
 	// DiffStats stores the current git diff statistics
 	diffStats *git.DiffStats
+
+	// ciStatus is the last known CI verdict for Branch. Deliberately not
+	// persisted: a verdict from a previous run of cs would be arbitrarily stale,
+	// and a fresh one arrives within a tick or two of startup.
+	ciStatus ci.Status
 
 	// selectedBranch is the existing branch to start on (empty = new branch from HEAD)
 	selectedBranch string
@@ -626,6 +632,17 @@ func (i *Instance) SetDiffStats(stats *git.DiffStats) {
 // GetDiffStats returns the current git diff statistics
 func (i *Instance) GetDiffStats() *git.DiffStats {
 	return i.diffStats
+}
+
+// SetCIStatus sets the CI verdict for this instance's branch. Should be called
+// from the main event loop to avoid data races with View.
+func (i *Instance) SetCIStatus(status ci.Status) {
+	i.ciStatus = status
+}
+
+// GetCIStatus returns the last known CI verdict for this instance's branch.
+func (i *Instance) GetCIStatus() ci.Status {
+	return i.ciStatus
 }
 
 // SendPrompt sends a prompt to the tmux session

--- a/ui/list.go
+++ b/ui/list.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"claude-squad/log"
 	"claude-squad/session"
+	"claude-squad/session/ci"
 	"errors"
 	"fmt"
 	"strings"
@@ -15,6 +16,18 @@ import (
 const readyIcon = "● "
 const pausedIcon = "⏸ "
 
+// CI badge icons. The verdict is a glyph so it reads at a glance, and the colour
+// carries the same information again for anyone scanning the column rather than
+// reading the row.
+const (
+	ciSuccessIcon = "✓"
+	ciFailureIcon = "✗"
+	ciPendingIcon = "◌"
+	ciMergedIcon  = "◆"
+	ciClosedIcon  = "⊘"
+	ciNoPRIcon    = "–"
+)
+
 var readyStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#51bd73", Dark: "#51bd73"})
 
@@ -23,6 +36,18 @@ var addedLinesStyle = lipgloss.NewStyle().
 
 var removedLinesStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.Color("#de613e"))
+
+// Amber for "still running": the one CI state with no existing colour in the
+// palette. Success, failure and no-PR reuse addedLinesStyle, removedLinesStyle
+// and pausedStyle, so the badge introduces no colour the list does not already
+// use elsewhere.
+var ciPendingStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.AdaptiveColor{Light: "#b8860b", Dark: "#e3b341"})
+
+// Violet for a merged pull request, matching the colour GitHub itself uses for
+// the state, so it reads as "landed" rather than as another shade of pass/fail.
+var ciMergedStyle = lipgloss.NewStyle().
+	Foreground(lipgloss.AdaptiveColor{Light: "#8250df", Dark: "#a371f7"})
 
 var pausedStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.AdaptiveColor{Light: "#888888", Dark: "#888888"})
@@ -114,6 +139,63 @@ func (r *InstanceRenderer) setWidth(width int) {
 // ɹ and ɻ are other options.
 const branchIcon = "Ꮧ"
 
+// minBranchWidth is the fewest characters of a branch name worth keeping. Below
+// this the name stops being recognisable, so a badge that would push it there
+// costs the row its identity to save its decoration.
+const minBranchWidth = 6
+
+// visibleBranchWidth reports how many characters of a branch name survive in a
+// column of the given width, mirroring the truncation Render applies below.
+func visibleBranchWidth(branch string, column int) int {
+	width := runewidth.StringWidth(branch)
+	switch {
+	case column >= width:
+		return width
+	case column < 3:
+		return 0
+	default:
+		return column - 3 // the ellipsis takes the rest
+	}
+}
+
+// ciBadge renders a branch's CI verdict twice over: plain for width accounting,
+// styled for display. Both are empty when there is nothing to report, which is
+// also what a disabled feature and a not-yet-completed first lookup produce, so
+// the badge appears only once it can say something true.
+func ciBadge(status ci.Status, bg lipgloss.TerminalColor) (plain, styled string) {
+	var icon string
+	var style lipgloss.Style
+
+	switch status.State {
+	case ci.StateSuccess:
+		icon, style = ciSuccessIcon, addedLinesStyle
+	case ci.StateFailure:
+		icon, style = ciFailureIcon, removedLinesStyle
+	case ci.StatePending:
+		icon, style = ciPendingIcon, ciPendingStyle
+	// The three terminal states name themselves instead of showing the PR number.
+	// Nothing is going to change about them, so there is nothing to go and look at;
+	// what matters is the state, and cs documents none of its glyphs anywhere.
+	case ci.StateMerged:
+		plain = ciMergedIcon + " merged"
+		return plain, ciMergedStyle.Background(bg).Render(plain)
+	case ci.StateClosed:
+		plain = ciClosedIcon + " closed"
+		return plain, pausedStyle.Background(bg).Render(plain)
+	case ci.StateNoPR:
+		plain = ciNoPRIcon + " no PR"
+		return plain, pausedStyle.Background(bg).Render(plain)
+	default:
+		return "", ""
+	}
+
+	plain = icon
+	if status.PRNumber > 0 {
+		plain = fmt.Sprintf("%s #%d", icon, status.PRNumber)
+	}
+	return plain, style.Background(bg).Render(plain)
+}
+
 func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, hasMultipleRepos bool) string {
 	prefix := fmt.Sprintf(" %d. ", idx)
 	if idx >= 10 {
@@ -193,6 +275,22 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 			branch += fmt.Sprintf(" (%s)", repoName)
 		}
 	}
+	// Reserve the CI badge out of the width budget before the branch is truncated,
+	// so an overlong branch gives way to the verdict rather than pushing it off the
+	// end of the line.
+	ciPlain, ciStyled := ciBadge(i.GetCIStatus(), descS.GetBackground())
+	ciWidth := runewidth.StringWidth(ciPlain)
+	if ciWidth > 0 {
+		ciWidth += 2 // the spaces either side of the badge in branchLine
+	}
+	// Up to a point: the branch name is the row's identity and the badge is an
+	// extra, so on a pane too narrow for both it is the badge that gives way.
+	// Otherwise a 20-column list renders an icon, an ellipsis and no name at all.
+	if visibleBranchWidth(branch, remainingWidth-ciWidth) < minBranchWidth {
+		ciStyled, ciWidth = "", 0
+	}
+	remainingWidth -= ciWidth
+
 	// Don't show branch if there's no space for it. Or show ellipsis if it's too long.
 	branchWidth := runewidth.StringWidth(branch)
 	if remainingWidth < 0 {
@@ -213,7 +311,17 @@ func (r *InstanceRenderer) Render(i *session.Instance, idx int, selected bool, h
 		spaces = strings.Repeat(" ", remainingWidth)
 	}
 
-	branchLine := fmt.Sprintf("%s %s-%s%s%s", strings.Repeat(" ", len(prefix)), branchIcon, branch, spaces, diff)
+	ciSegment := ""
+	if ciStyled != "" {
+		// The padding spaces have to carry the row background themselves. They sit
+		// either side of an already-styled span whose trailing reset clears it, so a
+		// bare " " here renders as a black gap on the selected row rather than picking
+		// up its highlight. Same reason the diff separator below is styled.
+		pad := lipgloss.Style{}.Background(descS.GetBackground()).Render(" ")
+		ciSegment = pad + ciStyled + pad
+	}
+
+	branchLine := fmt.Sprintf("%s %s-%s%s%s%s", strings.Repeat(" ", len(prefix)), branchIcon, branch, spaces, ciSegment, diff)
 
 	// join title and subtitle
 	text := lipgloss.JoinVertical(

--- a/ui/list_test.go
+++ b/ui/list_test.go
@@ -2,9 +2,15 @@ package ui
 
 import (
 	"claude-squad/session"
+	"claude-squad/session/ci"
+	"claude-squad/session/git"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,4 +78,155 @@ func TestMoveWithSingleItem(t *testing.T) {
 
 	require.False(t, l.MoveUp())
 	require.False(t, l.MoveDown())
+}
+
+// newTestRenderer builds a renderer with a known width plus one instance whose
+// CI verdict the caller controls.
+func newTestRenderer(t *testing.T, width int, branch string, status ci.Status) (*InstanceRenderer, *session.Instance) {
+	t.Helper()
+	s := spinner.New()
+	r := &InstanceRenderer{spinner: &s}
+	r.setWidth(width)
+
+	inst, err := session.NewInstance(session.InstanceOptions{Title: "session", Path: ".", Program: "echo"})
+	require.NoError(t, err)
+	inst.Branch = branch
+	inst.SetCIStatus(status)
+	return r, inst
+}
+
+// branchLineOf returns the rendered line carrying the branch name.
+func branchLineOf(t *testing.T, out string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, branchIcon) {
+			return line
+		}
+	}
+	t.Fatalf("no branch line in rendered output %q", out)
+	return ""
+}
+
+func TestRenderCIBadge(t *testing.T) {
+	tests := []struct {
+		name   string
+		status ci.Status
+		want   string
+	}{
+		{
+			name:   "failure shows the glyph and PR number",
+			status: ci.Status{State: ci.StateFailure, PRNumber: 4420, Failed: 1},
+			want:   ciFailureIcon + " #4420",
+		},
+		{
+			name:   "success shows the glyph and PR number",
+			status: ci.Status{State: ci.StateSuccess, PRNumber: 12, Passed: 7},
+			want:   ciSuccessIcon + " #12",
+		},
+		{
+			name:   "still running shows the pending glyph",
+			status: ci.Status{State: ci.StatePending, PRNumber: 99, Pending: 3},
+			want:   ciPendingIcon + " #99",
+		},
+		{
+			name:   "a branch with no pull request says so",
+			status: ci.Status{State: ci.StateNoPR},
+			want:   ciNoPRIcon + " no PR",
+		},
+		{
+			// Not the PR number: nothing more is going to happen to it, and a merged
+			// PR is all-green, so a bare tick would read as "open and passing".
+			name:   "a merged pull request says merged, not passed",
+			status: ci.Status{State: ci.StateMerged, PRNumber: 4418},
+			want:   ciMergedIcon + " merged",
+		},
+		{
+			name:   "a closed pull request says closed",
+			status: ci.Status{State: ci.StateClosed, PRNumber: 4418},
+			want:   ciClosedIcon + " closed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, inst := newTestRenderer(t, 80, "feature", tt.status)
+			require.Contains(t, branchLineOf(t, r.Render(inst, 1, false, false)), tt.want)
+		})
+	}
+}
+
+// StateUnknown covers three cases that must all look identical: the feature is
+// disabled, gh is unavailable, and the first lookup has not come back yet. None
+// of them may draw a badge, or the list would claim a verdict it does not have.
+func TestRenderNoBadgeWithoutAVerdict(t *testing.T) {
+	r, inst := newTestRenderer(t, 80, "feature", ci.Status{})
+	line := branchLineOf(t, r.Render(inst, 1, false, false))
+
+	for _, icon := range []string{ciSuccessIcon, ciFailureIcon, ciPendingIcon, ciMergedIcon, ciClosedIcon, ciNoPRIcon} {
+		require.NotContains(t, line, icon)
+	}
+}
+
+// The badge is reserved out of the line's width budget before the branch name is
+// truncated, so adding one must not change the rendered width at all -- an
+// overlong branch has to give way instead. Regression guard for the width
+// accounting in Render.
+//
+// Compared against the no-badge baseline rather than against r.width, because
+// the branch line already exceeds r.width by 2 upstream: listDescStyle carries
+// Padding(0, 1, 1, 1) and remainingWidth never subtracts it. That is not this
+// feature's bug to encode as correct, so the assertion is "the badge costs
+// nothing", which is what this change is responsible for.
+func TestRenderCIBadgeDoesNotChangeLineWidth(t *testing.T) {
+	const longBranch = "a-very-long-branch-name-that-cannot-possibly-fit-on-one-line"
+
+	badged := []ci.Status{
+		{State: ci.StateNoPR},
+		{State: ci.StateMerged, PRNumber: 4418},
+		{State: ci.StateClosed, PRNumber: 4418},
+		{State: ci.StateFailure, PRNumber: 4420},
+		{State: ci.StatePending, PRNumber: 7},
+		{State: ci.StateSuccess, PRNumber: 123456},
+	}
+
+	for _, width := range []int{20, 30, 40, 60, 80, 120} {
+		base, baseInst := newTestRenderer(t, width, longBranch, ci.Status{})
+		baseWidth := lipgloss.Width(branchLineOf(t, base.Render(baseInst, 1, false, false)))
+
+		for _, status := range badged {
+			r, inst := newTestRenderer(t, width, longBranch, status)
+			line := branchLineOf(t, r.Render(inst, 1, false, false))
+			require.Equal(t, baseWidth, lipgloss.Width(line),
+				"width %d, state %v: badge changed the line width", width, status.State)
+			require.Contains(t, line, "-"+runewidth.Truncate(longBranch, 3, ""),
+				"width %d, state %v: branch name vanished entirely", width, status.State)
+		}
+	}
+}
+
+// A bare space sitting after an already-styled span renders with the terminal's
+// own background rather than the row's, which showed up as a black block in the
+// middle of the highlighted row. Guard the whole class rather than the one space:
+// on a selected row, no reset may be immediately followed by an unstyled space.
+func TestRenderSelectedRowHasNoUnstyledGaps(t *testing.T) {
+	previous := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(previous) })
+
+	for _, status := range []ci.Status{
+		{State: ci.StateNoPR},
+		{State: ci.StateMerged, PRNumber: 4418},
+		{State: ci.StateClosed, PRNumber: 4418},
+		{State: ci.StatePending, PRNumber: 4420},
+		{State: ci.StateFailure, PRNumber: 4420},
+		{State: ci.StateSuccess, PRNumber: 4420},
+	} {
+		r, inst := newTestRenderer(t, 80, "task-5636-vis-6", status)
+		inst.SetDiffStats(&git.DiffStats{Added: 9997, Removed: 192})
+
+		line := branchLineOf(t, r.Render(inst, 1, true, false))
+		require.NotContains(t, line, "\x1b[0m ",
+			"state %v: a style reset is followed by an unstyled space, which renders as a gap in the row highlight",
+			status.State)
+	}
 }


### PR DESCRIPTION
## What

Shows each session's GitHub CI verdict in the instance list, to the right of the branch name.

```
  1.  claude-md-trim                                                   ●
      Ꮧ-NO-TASK-claude-md-restructure                 ◆ merged +2200,-12
  2.  5636-Vis-6                                                       ●
      Ꮧ-task-5636-vis-6                               ✗ #4420 +9997,-192
  3.  signal-pills                                                     ●
      Ꮧ-TASK-5665                                     ✓ #4406 +1043,-207
  4.  ai-judge                                                         ●
      Ꮧ-TASK-5686                                       ◌ #4416 +412,-88
  5.  abandoned                                                        ●
      Ꮧ-TASK-old                                         ⊘ closed +30,-4
  6.  brand-new                                                        ●
      Ꮧ-task-brand-new                                     – no PR +5,-0
```

`◌` amber = a check is running · `✗` red = a check failed · `✓` green = all passed · `◆` violet = merged · `⊘` grey = closed unmerged · `–` grey = no PR · nothing = no verdict yet.

The three terminal states name themselves instead of showing the PR number: nothing more is going to happen to them, so there is nothing to go and look at, and cs documents none of its glyphs anywhere today.

## Why

With several sessions in flight, "is this branch green yet?" currently means leaving cs for a browser or running `gh pr checks` per branch. The row already carries the branch name and its diff stats; the verdict belongs in the same place.

## How

A new `session/ci` package derives one verdict per session from `gh pr view <branch> --json number,state,statusCheckRollup`, run with `cmd.Dir` set to the instance's repo so gh resolves the remote itself.

Four decisions worth calling out:

**The cache is stale-while-revalidate with a 30s TTL, and `ci.Get` never blocks.** It is read from `tickUpdateMetadataCmd`, which also computes the git diffs and only re-schedules once every goroutine has returned — a ~700ms gh round trip there would directly stall diff-stat updates. `Get` returns the cached verdict and starts a refresh only when stale, with an in-flight guard so a 500ms reader cannot pile up fetches on a ~1s call. The first lookup for a worktree therefore shows no badge, and it appears a tick or two later.

**A merged or closed PR reports its own state, not its checks.** Every check on a merged PR is green, so classifying one by its rollup renders it identically to an open branch that is merely passing; an abandoned PR would likewise show a green tick for work nobody merged.

**The branch comes from the worktree's HEAD, with the session's recorded name as the fallback.** Renaming the branch or checking out a different one from inside a worktree is common, and the recorded name then has no PR while the real one does — keying on it reported "no PR" for work that had already merged. The cache is keyed on the worktree rather than a branch name for the same reason, so a switch needs no second entry to stop reporting the old verdict.

**Skipped and cancelled checks are ignored rather than counted as failures.** A cancelled run is nearly always one superseded by a newer push, and skipped jobs are the normal result of path filters. Counting either as red would leave most healthy branches showing a failure.

The badge is reserved out of the width budget before the branch name is truncated, but dropped entirely when that would leave fewer than `minBranchWidth` characters of the name — at 20 columns the row otherwise rendered an icon, an ellipsis and no name. Its padding carries the row background explicitly, since a bare space after an already-styled span renders as a gap in the selected row's highlight.

It degrades quietly: no `gh` on PATH, an unauthenticated `gh`, a non-GitHub remote, or a branch with no PR each produce either no badge or the "no PR" marker. An auth failure latches the feature off for the process rather than logging once per branch every 30s.

## Config

Opt out with `"github_ci_status": false` in `config.json`. The field is a `*bool` so that a config written before this feature existed — which has no such key — reads as enabled rather than disabled.

## Testing

- `go test ./...` passes. New: classification cases, terminal-state mapping, badge content per state, no-badge-without-a-verdict, the width cost of the badge, and a guard that no style reset is followed by an unstyled space on a selected row
- `golangci-lint run --fast` at v1.60.1, the version pinned in `lint.yml` — clean. `gofmt -l .` — clean
- Cross-compiled all five `build.yml` matrix targets: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64
- Checked end to end against a live repo: a passing PR, a PR with failing checks, a PR with a check still running, a merged PR whose remote branch had been deleted, and a branch with no PR

## Noted, deliberately not fixed here

Two things I found and left alone, happy to send either separately:

1. On `main` the branch line already exceeds `r.width` by exactly 2 columns at every width: `listDescStyle` carries `Padding(0, 1, 1, 1)` and `remainingWidth` never subtracts it. That is also why the width test here compares against the no-badge baseline rather than against `r.width`.
2. The list still displays the branch name a session was *created* with, so a worktree whose branch was renamed shows the old name next to the new branch's verdict. Making the label follow HEAD too is a behaviour change wider than this feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)