### PR TITLE
Add Forgejo/tea CLI support alongside gh

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,47 @@
+# armarquez/claude-squad — a fork of smtg-ai/claude-squad carrying Forgejo/tea CLI
+# support (upstream only speaks GitHub/gh) as a small patch on top of upstream. These
+# recipes exist to keep that patch easy to rebase forward as upstream moves.
+
+default:
+    @just --list
+
+# One-time: point this fork at smtg-ai/claude-squad so `sync-upstream` has something to fetch
+add-upstream:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if git remote get-url upstream >/dev/null 2>&1; then
+        echo "✓ upstream already set: $(git remote get-url upstream)"
+    else
+        git remote add upstream https://github.com/smtg-ai/claude-squad.git
+        echo "✓ added upstream -> https://github.com/smtg-ai/claude-squad.git"
+    fi
+
+# Verify without changing anything: is this branch behind upstream/main?
+check-upstream:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! git remote get-url upstream >/dev/null 2>&1; then
+        echo "✗ no upstream remote — run: just add-upstream"
+        exit 1
+    fi
+    git fetch upstream --quiet
+    behind=$(git rev-list --count HEAD..upstream/main)
+    if [ "$behind" -eq 0 ]; then
+        echo "✓ up to date with upstream/main"
+    else
+        echo "⚠ $behind commit(s) behind upstream/main — run: just sync-upstream"
+    fi
+
+# Rebase local Forgejo/tea patches on top of latest upstream/main. Does NOT push —
+# review + resolve conflicts, then `git push --force-with-lease origin main` yourself.
+sync-upstream: add-upstream
+    git fetch upstream
+    git rebase upstream/main
+
+# Build the binary
+build:
+    go build ./...
+
+# Run the test suite
+test:
+    go test ./...

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	version     = "1.0.20"
+	version     = "1.0.21"
 	programFlag string
 	autoYesFlag bool
 	daemonFlag  bool
@@ -140,7 +140,7 @@ var (
 		Short: "Print the version number",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("%s version %s\n", binName, version)
-			fmt.Printf("https://github.com/smtg-ai/claude-squad/releases/tag/v%s\n", version)
+			fmt.Printf("https://github.com/armarquez/claude-squad/releases/tag/v%s\n", version)
 		},
 	}
 )

--- a/session/git/forge.go
+++ b/session/git/forge.go
@@ -1,0 +1,70 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// forgeKind identifies which git-hosting CLI backend to use for operations that need
+// one (pushing/syncing a branch, opening it in a browser).
+type forgeKind string
+
+const (
+	forgeGitHub  forgeKind = "github"
+	forgeForgejo forgeKind = "forgejo"
+)
+
+// detectForge inspects the origin remote URL to decide which CLI backend to use.
+// Defaults to forgeGitHub on any detection failure or unrecognized host, preserving
+// existing behavior for anyone not using Forgejo.
+func detectForge(repoPath string) forgeKind {
+	cmd := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin")
+	output, err := cmd.Output()
+	if err != nil {
+		return forgeGitHub
+	}
+	if strings.Contains(string(output), "github.com") {
+		return forgeGitHub
+	}
+	return forgeForgejo
+}
+
+// checkTeaCLI checks if the Forgejo/Gitea CLI (tea) is installed and has at least one
+// configured login. Mirrors checkGHCLI in util.go.
+func checkTeaCLI() error {
+	if _, err := exec.LookPath("tea"); err != nil {
+		return fmt.Errorf("Forgejo/Gitea CLI (tea) is not installed. Please install it first")
+	}
+
+	output, err := exec.Command("tea", "logins", "list", "-o", "simple").Output()
+	if err != nil || len(strings.TrimSpace(string(output))) == 0 {
+		return fmt.Errorf("tea CLI has no configured logins. Please run 'tea login add' first")
+	}
+
+	return nil
+}
+
+// pushViaGit pushes the branch to origin with a plain `git push -u`. This is the
+// Forgejo push path (Forgejo has no fork/sync-aware CLI equivalent to `gh repo sync`),
+// and matches the same fallback PushChanges already uses if `gh repo sync` fails.
+func pushViaGit(worktreePath, branchName string) error {
+	cmd := exec.Command("git", "push", "-u", "origin", branchName)
+	cmd.Dir = worktreePath
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to push branch: %s (%w)", output, err)
+	}
+	return nil
+}
+
+// openBranchURLForgejo opens the repository in the browser via `tea open`, which infers
+// the repo from the worktree's local git remote. Unlike `gh browse --branch`, tea has no
+// flag to target a specific branch — this opens the repo's default view instead.
+func openBranchURLForgejo(worktreePath string) error {
+	cmd := exec.Command("tea", "open")
+	cmd.Dir = worktreePath
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to open repo URL: %w", err)
+	}
+	return nil
+}

--- a/session/git/forge_test.go
+++ b/session/git/forge_test.go
@@ -1,0 +1,35 @@
+package git
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectForge_GitHub(t *testing.T) {
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	mustRunGit(t, "", "init", repoPath)
+	mustRunGit(t, repoPath, "remote", "add", "origin", "git@github.com:armarquez/claude-squad.git")
+
+	if got := detectForge(repoPath); got != forgeGitHub {
+		t.Errorf("detectForge() = %q, want %q", got, forgeGitHub)
+	}
+}
+
+func TestDetectForge_Forgejo(t *testing.T) {
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	mustRunGit(t, "", "init", repoPath)
+	mustRunGit(t, repoPath, "remote", "add", "origin", "https://git.mqz.casa/boogey/claude-squad.git")
+
+	if got := detectForge(repoPath); got != forgeForgejo {
+		t.Errorf("detectForge() = %q, want %q", got, forgeForgejo)
+	}
+}
+
+func TestDetectForge_NoRemote(t *testing.T) {
+	repoPath := filepath.Join(t.TempDir(), "repo")
+	mustRunGit(t, "", "init", repoPath)
+
+	if got := detectForge(repoPath); got != forgeGitHub {
+		t.Errorf("detectForge() = %q, want %q (safe default)", got, forgeGitHub)
+	}
+}

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -69,7 +69,12 @@ func (g *GitWorktree) runGitCommand(path string, args ...string) (string, error)
 
 // PushChanges commits and pushes changes in the worktree to the remote branch
 func (g *GitWorktree) PushChanges(commitMessage string, open bool) error {
-	if err := checkGHCLI(); err != nil {
+	forge := detectForge(g.worktreePath)
+	if forge == forgeForgejo {
+		if err := checkTeaCLI(); err != nil {
+			return err
+		}
+	} else if err := checkGHCLI(); err != nil {
 		return err
 	}
 
@@ -91,6 +96,18 @@ func (g *GitWorktree) PushChanges(commitMessage string, open bool) error {
 			log.ErrorLog.Print(err)
 			return fmt.Errorf("failed to commit changes: %w", err)
 		}
+	}
+
+	if forge == forgeForgejo {
+		if err := pushViaGit(g.worktreePath, g.branchName); err != nil {
+			return err
+		}
+		if open {
+			if err := g.OpenBranchURL(); err != nil {
+				log.ErrorLog.Printf("failed to open branch URL: %v", err)
+			}
+		}
+		return nil
 	}
 
 	// First push the branch to remote to ensure it exists
@@ -189,6 +206,13 @@ func (g *GitWorktree) IsBranchCheckedOut() (bool, error) {
 
 // OpenBranchURL opens the branch URL in the default browser
 func (g *GitWorktree) OpenBranchURL() error {
+	if detectForge(g.worktreePath) == forgeForgejo {
+		if err := checkTeaCLI(); err != nil {
+			return err
+		}
+		return openBranchURLForgejo(g.worktreePath)
+	}
+
 	// Check if GitHub CLI is available
 	if err := checkGHCLI(); err != nil {
 		return err


### PR DESCRIPTION
## Summary
- `gh` (GitHub CLI) was hardcoded for pushing a session's branch and opening it in a browser — broke for worktrees whose `origin` is a self-hosted Forgejo instance instead of GitHub.
- `session/git/forge.go` (new): detects the git host from the `origin` remote URL (defaults to GitHub on any detection failure, preserving existing behavior), plus a `tea`-backed push/open path.
- `session/git/worktree_git.go`: dispatches to the new path via small additive branches, existing `gh`-based code untouched — keeps future `git rebase upstream/main` conflict-free on this file.
- Adds a `justfile` (`add-upstream`/`check-upstream`/`sync-upstream`) to make pulling in upstream changes straightforward.
- Bumps version to 1.0.21 and points the `version` command's release URL at this fork instead of `smtg-ai/claude-squad`.

## How was it tested?
- [x] `go build ./...` / `go vet ./...`
- [x] `go test ./...` — full suite passes, plus new `session/git/forge_test.go` (GitHub remote → github, Forgejo remote → forgejo, no remote → github default)
- [x] `just check-upstream` against the real `upstream` remote
- [x] Manual: built binary, ran `claude-squad version`, confirmed it prints 1.0.21 and the fork's release URL

## Reviewers
@armarquez